### PR TITLE
feat: implement `data` sub-module

### DIFF
--- a/.cspell/python.txt
+++ b/.cspell/python.txt
@@ -21,6 +21,9 @@ kwargs
 lambdification
 lambdify
 lhcb
+linspace
+matplotlib
+meshgrid
 nbconvert
 ncols
 ndarray

--- a/docs/cross-check.ipynb
+++ b/docs/cross-check.ipynb
@@ -10,20 +10,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "%run ./phase-space.ipynb"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,7 +31,6 @@
    },
    "outputs": [],
    "source": [
-    "# pyright: reportUndefinedVariable=false\n",
     "from __future__ import annotations\n",
     "\n",
     "import json\n",
@@ -56,8 +41,30 @@
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "from tqdm.notebook import tqdm\n",
     "\n",
-    "from polarization.io import as_latex, display_latex, perform_cached_doit\n",
-    "from polarization.lhcb import get_conversion_factor, parameter_key_to_symbol"
+    "from polarization.amplitude import DalitzPlotDecompositionBuilder\n",
+    "from polarization.data import create_data_transformer\n",
+    "from polarization.io import (\n",
+    "    as_latex,\n",
+    "    display_latex,\n",
+    "    mute_jax_warnings,\n",
+    "    perform_cached_doit,\n",
+    ")\n",
+    "from polarization.lhcb import (\n",
+    "    get_conversion_factor,\n",
+    "    load_model_parameters,\n",
+    "    load_three_body_decays,\n",
+    "    parameter_key_to_symbol,\n",
+    ")\n",
+    "\n",
+    "mute_jax_warnings()\n",
+    "\n",
+    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "decay = dynamics_configurator.decay\n",
+    "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
+    "amplitude_builder.dynamics_choices = dynamics_configurator\n",
+    "model = amplitude_builder.formulate()\n",
+    "imported_parameter_values = load_model_parameters(\"../data/modelparameters.json\", decay)\n",
+    "model.parameter_defaults.update(imported_parameter_values)"
    ]
   },
   {
@@ -89,6 +96,7 @@
    },
    "outputs": [],
    "source": [
+    "σ1, σ2, σ3 = sp.symbols(\"sigma1:4\", nonnegative=True)\n",
     "lineshape_vars = {k: v for k, v in crosscheck_data[\"mainvars\"].items()}\n",
     "lineshape_subs = {\n",
     "    σ1: lineshape_vars[\"m2kpi\"],\n",
@@ -231,10 +239,14 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fixed_parameters = {\n",
+    "production_couplings = {\n",
     "    symbol: value\n",
     "    for symbol, value in model.parameter_defaults.items()\n",
-    "    if symbol not in production_couplings\n",
+    "    if isinstance(symbol, sp.Indexed)\n",
+    "    if \"production\" in str(symbol)\n",
+    "}\n",
+    "fixed_parameters = {\n",
+    "    s: v for s, v in model.parameter_defaults.items() if s not in production_couplings\n",
     "}\n",
     "amplitude_funcs = {\n",
     "    k: create_parametrized_function(\n",
@@ -277,6 +289,7 @@
    },
    "outputs": [],
    "source": [
+    "transformer = create_data_transformer(model)\n",
     "input_data = {\n",
     "    str(σ1): amplitude_vars[\"m2kpi\"],\n",
     "    str(σ2): amplitude_vars[\"m2pk\"],\n",

--- a/docs/intensity-distribution.ipynb
+++ b/docs/intensity-distribution.ipynb
@@ -10,20 +10,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "%run ./phase-space.ipynb"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,7 +31,6 @@
    },
    "outputs": [],
    "source": [
-    "# pyright: reportUndefinedVariable=false\n",
     "from __future__ import annotations\n",
     "\n",
     "import logging\n",
@@ -63,7 +48,21 @@
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "from tqdm.notebook import tqdm\n",
     "\n",
-    "from polarization.io import perform_cached_doit"
+    "from polarization.amplitude import DalitzPlotDecompositionBuilder\n",
+    "from polarization.data import create_data_transformer, generate_meshgrid_sample\n",
+    "from polarization.decay import Particle\n",
+    "from polarization.io import mute_jax_warnings, perform_cached_doit\n",
+    "from polarization.lhcb import load_model_parameters, load_three_body_decays\n",
+    "\n",
+    "mute_jax_warnings()\n",
+    "\n",
+    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "decay = dynamics_configurator.decay\n",
+    "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
+    "amplitude_builder.dynamics_choices = dynamics_configurator\n",
+    "model = amplitude_builder.formulate()\n",
+    "imported_parameter_values = load_model_parameters(\"../data/modelparameters.json\", decay)\n",
+    "model.parameter_defaults.update(imported_parameter_values)"
    ]
   },
   {
@@ -92,8 +91,11 @@
    "outputs": [],
    "source": [
     "def assert_all_symbols_defined(expr: sp.Expr) -> None:\n",
+    "    sigmas = sp.symbols(\"sigma1:4\", nonnegative=True)\n",
     "    remaining_symbols = expr.xreplace(model.parameter_defaults).free_symbols\n",
-    "    assert remaining_symbols <= set(model.variables) | {σ1, σ2, σ3}\n",
+    "    remaining_symbols -= set(model.variables)\n",
+    "    remaining_symbols -= set(sigmas)\n",
+    "    assert not remaining_symbols, remaining_symbols\n",
     "\n",
     "\n",
     "assert_all_symbols_defined(unfolded_intensity_expr)\n",
@@ -121,13 +123,17 @@
    },
    "outputs": [],
    "source": [
-    "free_parameters = dict(production_couplings)\n",
+    "free_parameters = {\n",
+    "    symbol: value\n",
+    "    for symbol, value in model.parameter_defaults.items()\n",
+    "    if isinstance(symbol, sp.Indexed)\n",
+    "    if \"production\" in str(symbol)\n",
+    "}\n",
     "fixed_parameters = {\n",
     "    symbol: value\n",
     "    for symbol, value in model.parameter_defaults.items()\n",
     "    if symbol not in free_parameters\n",
     "}\n",
-    "fixed_parameters.update(masses)\n",
     "subs_intensity_expr = unfolded_intensity_expr.xreplace(fixed_parameters)"
    ]
   },
@@ -211,8 +217,12 @@
     "ax.set_xlabel(s1_label)\n",
     "ax.set_ylabel(s2_label)\n",
     "\n",
-    "X, Y, data_sample, phsp_filter = generate_uniform_phsp(resolution=1_000)\n",
-    "Z = phsp_filter * intensity_func(data_sample)\n",
+    "phsp_sample = generate_meshgrid_sample(decay, resolution=1_000)\n",
+    "transformer = create_data_transformer(model)\n",
+    "data_sample = transformer(phsp_sample)\n",
+    "X = phsp_sample[\"sigma1\"]\n",
+    "Y = phsp_sample[\"sigma2\"]\n",
+    "Z = intensity_func(data_sample)\n",
     "mesh = ax.pcolormesh(X, Y, Z, norm=LogNorm())\n",
     "fig.colorbar(mesh, ax=ax)\n",
     "plt.show()"
@@ -359,11 +369,7 @@
    },
    "outputs": [],
    "source": [
-    "def interference_intensity(\n",
-    "    data,\n",
-    "    chain1: list[str],\n",
-    "    chain2: list[str],\n",
-    ") -> float:\n",
+    "def interference_intensity(data, chain1: list[str], chain2: list[str]) -> float:\n",
     "    I_interference = sub_intensity(data, chain1 + chain2)\n",
     "    I_chain1 = sub_intensity(data, chain1)\n",
     "    I_chain2 = sub_intensity(data, chain2)\n",
@@ -446,7 +452,7 @@
    },
    "outputs": [],
    "source": [
-    "vmax = np.max(decay_rates)\n",
+    "vmax = np.max(np.abs(decay_rates))\n",
     "fig, ax = plt.subplots(figsize=(9, 9))\n",
     "ax.set_title(\"Rate matrix for isobars (%)\")\n",
     "ax.matshow(np.rot90(decay_rates).T, cmap=plt.cm.coolwarm, vmin=-vmax, vmax=+vmax)\n",

--- a/docs/phase-space.ipynb
+++ b/docs/phase-space.ipynb
@@ -8,20 +8,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "%run ./amplitude-model.ipynb"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,184 +23,137 @@
      "source_hidden": true
     },
     "tags": [
-     "hide-cell",
-     "scroll-input"
+     "hide-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "# pyright: reportUndefinedVariable=false\n",
-    "import logging\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
     "import sympy as sp\n",
-    "from ampform.kinematics.phasespace import is_within_phasespace\n",
-    "from tensorwaves.data import (\n",
-    "    IntensityDistributionGenerator,\n",
-    "    NumpyDomainGenerator,\n",
-    "    NumpyUniformRNG,\n",
+    "from ampform.kinematics.phasespace import (\n",
+    "    Kallen,\n",
+    "    Kibble,\n",
+    "    compute_third_mandelstam,\n",
+    "    is_within_phasespace,\n",
     ")\n",
-    "from tensorwaves.data.transform import SympyDataTransformer\n",
-    "from tensorwaves.function.sympy import create_function\n",
+    "from matplotlib.colors import LogNorm\n",
     "\n",
-    "from polarization.io import display_latex\n",
+    "from polarization.data import (\n",
+    "    create_mass_symbol_mapping,\n",
+    "    create_phase_space_filter,\n",
+    "    generate_meshgrid_sample,\n",
+    "    generate_phasespace_sample,\n",
+    ")\n",
+    "from polarization.io import display_doit, display_latex, mute_jax_warnings\n",
+    "from polarization.lhcb import load_three_body_decays\n",
     "\n",
-    "JAX_LOGGER = logging.getLogger(\"absl\")\n",
-    "JAX_LOGGER.setLevel(logging.ERROR)"
+    "mute_jax_warnings()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "m0, m1, m2, m3 = sp.symbols(\"m:4\", nonnegative=True)\n",
-    "σ1, σ2, σ3 = sp.symbols(\"sigma1:4\", nonnegative=True)\n",
-    "σ3_expr = m0**2 + m1**2 + m2**2 + m3**2 - σ1 - σ2\n",
-    "display_latex({σ3: σ3_expr})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "is_within_phasespace(σ1, σ2, m0, m1, m2, m3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "hide-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "masses = {\n",
-    "    s: model.parameter_defaults[s]\n",
-    "    for s in sorted(model.parameter_defaults, key=str)\n",
-    "    if s in {m0, m1, m2, m3}\n",
-    "}\n",
-    "display_latex(masses)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "in_phsp_expr = is_within_phasespace(σ1, σ2, m0, m1, m2, m3).doit()\n",
-    "in_phsp_expr = in_phsp_expr.subs(σ3, σ3_expr).subs(masses)\n",
-    "assert in_phsp_expr.free_symbols == {σ1, σ2}, in_phsp_expr.free_symbols\n",
-    "in_phsp = create_function(in_phsp_expr, backend=\"numpy\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "m0_val, m1_val, m2_val, m3_val = masses.values()\n",
-    "σ1_min = (m2_val + m3_val) ** 2\n",
-    "σ1_max = (m0_val - m1_val) ** 2\n",
-    "σ2_min = (m1_val + m3_val) ** 2\n",
-    "σ2_max = (m0_val - m2_val) ** 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "kinematic_variables = {\n",
-    "    symbol: expression.doit().subs(masses)\n",
-    "    for symbol, expression in model.variables.items()\n",
-    "}\n",
-    "kinematic_variables.update({s: s for s in [σ1, σ2, σ3]})  # include identity\n",
-    "transformer = SympyDataTransformer.from_sympy(kinematic_variables, backend=\"jax\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def generate_uniform_phsp(resolution: int):\n",
-    "    x = np.linspace(σ1_min, σ1_max, num=resolution)\n",
-    "    y = np.linspace(σ2_min, σ2_max, num=resolution)\n",
-    "    compute_third_mandelstam = create_function(σ3_expr.subs(masses), backend=\"jax\")\n",
-    "    X, Y = np.meshgrid(x, y)\n",
-    "    Z = compute_third_mandelstam.function(X, Y)\n",
-    "    σ_arrays = {\"sigma1\": X, \"sigma2\": Y, \"sigma3\": Z}\n",
-    "    data = transformer(σ_arrays)\n",
-    "    phsp = in_phsp(σ_arrays)\n",
-    "    return X, Y, data, phsp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{seealso}\n",
+    "AmpForm's {doc}`ampform:usage/kinematics` page.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "def generate_phasespace_sample(n_events: int, seed=None):\n",
-    "    in_phsp_expr = (\n",
-    "        is_within_phasespace(σ1, σ2, m0, m1, m2, m3, outside_value=0)\n",
-    "        .doit()\n",
-    "        .subs(σ3, σ3_expr)\n",
-    "        .subs(masses)\n",
-    "    )\n",
-    "    phsp_filter = create_function(in_phsp_expr, backend=\"numpy\")\n",
-    "    rng = NumpyUniformRNG(seed)\n",
-    "    domain_generator = NumpyDomainGenerator(\n",
-    "        boundaries={\n",
-    "            \"sigma1\": (σ1_min, σ1_max),\n",
-    "            \"sigma2\": (σ2_min, σ2_max),\n",
-    "        }\n",
-    "    )\n",
-    "    phsp_generator = IntensityDistributionGenerator(domain_generator, phsp_filter)\n",
-    "    phsp = phsp_generator.generate(n_events, rng)\n",
-    "    compute_third_mandelstam = create_function(σ3_expr.subs(masses), backend=\"numpy\")\n",
-    "    phsp[\"sigma3\"] = compute_third_mandelstam(phsp)\n",
-    "    return phsp"
+    "m0, mi, mj, mk = sp.symbols(\"m0 m_(i:k)\", nonnegative=True)\n",
+    "σi, σj, σk = sp.symbols(\"sigma_(i:k)\", nonnegative=True)\n",
+    "is_within_phasespace(σi, σj, m0, mi, mj, mk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "display_doit(Kibble(σi, σj, σk, m0, mi, mj, mk))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "display_doit(Kallen(*sp.symbols(\"x:z\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m1, m2, m3 = sp.symbols(\"m1:4\")\n",
+    "display_latex({σk: compute_third_mandelstam(σi, σj, m0, m1, m2, m3)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "decay = dynamics_configurator.decay\n",
+    "display_latex(create_mass_symbol_mapping(decay))"
    ]
   },
   {
@@ -238,26 +177,80 @@
      "source_hidden": true
     },
     "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def plot_phsp_boundary(ax, x_mandelstam: int, y_mandelstam: int):\n",
+    "    ax.set_xticks([])\n",
+    "    ax.set_xlabel(Rf\"$\\sigma_{x_mandelstam}$\")\n",
+    "    ax.set_ylabel(Rf\"$\\sigma_{y_mandelstam}$\")\n",
+    "    phsp = generate_meshgrid_sample(decay, resolution, x_mandelstam, y_mandelstam)\n",
+    "    phsp_filter = create_phase_space_filter(\n",
+    "        decay, x_mandelstam, y_mandelstam, outside_value=0\n",
+    "    )\n",
+    "    mesh = ax.contour(\n",
+    "        phsp[f\"sigma{x_mandelstam}\"],\n",
+    "        phsp[f\"sigma{y_mandelstam}\"],\n",
+    "        phsp_filter(phsp),\n",
+    "        colors=\"black\",\n",
+    "    )\n",
+    "    contour = mesh.collections[0]\n",
+    "    contour.set_facecolor(\"lightgray\")\n",
+    "\n",
+    "\n",
+    "resolution = 500\n",
+    "fig, ax = plt.subplots(figsize=(5, 5), tight_layout=True)\n",
+    "plot_phsp_boundary(ax, 1, 2)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
      "remove-input"
     ]
    },
    "outputs": [],
    "source": [
-    "def __plot_phsp():\n",
-    "    X, Y, _, phsp = generate_uniform_phsp(resolution=500)\n",
-    "    phsp = np.nan_to_num(phsp)\n",
-    "    _, ax = plt.subplots(figsize=(4, 4))\n",
-    "    ax.set_xlabel(R\"$\\sigma_1$\")\n",
-    "    ax.set_ylabel(R\"$\\sigma_2$\")\n",
+    "%config InlineBackend.figure_formats = ['png']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def plot_phsp_distribution(ax, x_mandelstam: int, y_mandelstam: int):\n",
     "    ax.set_xticks([])\n",
-    "    ax.set_yticks([])\n",
-    "    mesh = ax.contour(X, Y, phsp, colors=\"black\")\n",
-    "    contour = mesh.collections[0]\n",
-    "    contour.set_facecolor(\"lightgray\")\n",
-    "    plt.show()\n",
+    "    ax.set_xlabel(Rf\"$\\sigma_{x_mandelstam}$\")\n",
+    "    ax.set_ylabel(Rf\"$\\sigma_{y_mandelstam}$\")\n",
+    "    ax.hist2d(\n",
+    "        phsp[f\"sigma{x_mandelstam}\"],\n",
+    "        phsp[f\"sigma{y_mandelstam}\"],\n",
+    "        bins=500,\n",
+    "        norm=LogNorm(),\n",
+    "    )\n",
     "\n",
     "\n",
-    "__plot_phsp()"
+    "phsp = generate_phasespace_sample(decay, n_events=10_000_000, seed=0)\n",
+    "fig, axes = plt.subplots(ncols=3, figsize=(12, 4.5), tight_layout=True)\n",
+    "plot_phsp_distribution(axes[0], 1, 2)\n",
+    "plot_phsp_distribution(axes[1], 2, 3)\n",
+    "plot_phsp_distribution(axes[2], 3, 1)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
    ]
   }
  ],

--- a/docs/polarization.ipynb
+++ b/docs/polarization.ipynb
@@ -8,20 +8,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "%run ./phase-space.ipynb"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,22 +29,38 @@
    },
    "outputs": [],
    "source": [
-    "# pyright: reportUndefinedVariable=false\n",
     "from __future__ import annotations\n",
     "\n",
     "import jax.numpy as jnp\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import sympy as sp\n",
-    "from IPython.display import Markdown, Math\n",
+    "from IPython.display import Markdown, Math, display\n",
     "from matplotlib import cm\n",
     "from matplotlib.colors import LogNorm\n",
     "from tensorwaves.function.sympy import create_parametrized_function\n",
     "from tqdm.notebook import tqdm\n",
     "\n",
     "from polarization import formulate_polarization\n",
+    "from polarization.amplitude import DalitzPlotDecompositionBuilder\n",
+    "from polarization.data import (\n",
+    "    create_data_transformer,\n",
+    "    generate_meshgrid_sample,\n",
+    "    generate_phasespace_sample,\n",
+    ")\n",
     "from polarization.function import compute_sub_function\n",
-    "from polarization.io import perform_cached_doit"
+    "from polarization.io import mute_jax_warnings, perform_cached_doit\n",
+    "from polarization.lhcb import load_model_parameters, load_three_body_decays\n",
+    "\n",
+    "mute_jax_warnings()\n",
+    "\n",
+    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "decay = dynamics_configurator.decay\n",
+    "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
+    "amplitude_builder.dynamics_choices = dynamics_configurator\n",
+    "model = amplitude_builder.formulate()\n",
+    "imported_parameter_values = load_model_parameters(\"../data/modelparameters.json\", decay)\n",
+    "model.parameter_defaults.update(imported_parameter_values)"
    ]
   },
   {
@@ -98,17 +100,17 @@
    },
    "outputs": [],
    "source": [
-    "free_parameters = {\n",
+    "production_couplings = {\n",
     "    symbol: value\n",
     "    for symbol, value in model.parameter_defaults.items()\n",
-    "    if symbol in production_couplings\n",
+    "    if isinstance(symbol, sp.Indexed)\n",
+    "    if \"production\" in str(symbol)\n",
     "}\n",
     "fixed_parameters = {\n",
     "    symbol: value\n",
     "    for symbol, value in model.parameter_defaults.items()\n",
-    "    if symbol not in free_parameters\n",
-    "}\n",
-    "fixed_parameters.update(masses)"
+    "    if symbol not in production_couplings\n",
+    "}"
    ]
   },
   {
@@ -170,14 +172,14 @@
     "polarization_funcs = [\n",
     "    create_parametrized_function(\n",
     "        subs_polarization_exprs[xyz],\n",
-    "        parameters=free_parameters,\n",
+    "        parameters=production_couplings,\n",
     "        backend=\"jax\",\n",
     "    )\n",
     "    for xyz in tqdm(range(3))\n",
     "]\n",
     "intensity_func = create_parametrized_function(\n",
     "    subs_intensity_expr,\n",
-    "    parameters=free_parameters,\n",
+    "    parameters=production_couplings,\n",
     "    backend=\"jax\",\n",
     ")"
    ]
@@ -236,7 +238,11 @@
     "    display(Math(latex))\n",
     "\n",
     "\n",
-    "X, Y, data_sample, phsp_filter = generate_uniform_phsp(resolution=400)\n",
+    "phsp_sample = generate_meshgrid_sample(decay, resolution=400)\n",
+    "X = phsp_sample[\"sigma1\"]\n",
+    "Y = phsp_sample[\"sigma2\"]\n",
+    "transformer = create_data_transformer(model)\n",
+    "data_sample = transformer(phsp_sample)\n",
     "\n",
     "subsystem_identifiers = [\"K\", \"L\", \"D\"]\n",
     "subsystem_labels = [\"K^{**}\", R\"\\Lambda^{**}\", R\"\\Delta^{**}\"]\n",
@@ -450,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phsp = generate_phasespace_sample(100_000, seed=0)\n",
+    "phsp = generate_phasespace_sample(decay, 100_000, seed=0)\n",
     "%timeit transformer(phsp)\n",
     "phsp = transformer(phsp)"
    ]
@@ -483,7 +489,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X54, Y54, data_sample54, _ = generate_uniform_phsp(resolution=54)\n",
+    "phsp_meshgrid54 = generate_meshgrid_sample(decay, resolution=54)\n",
+    "data_sample54 = transformer(phsp_meshgrid54)\n",
+    "X54 = phsp_meshgrid54[\"sigma1\"]\n",
+    "Y54 = phsp_meshgrid54[\"sigma2\"]\n",
     "%timeit intensity_func(data_sample54)"
    ]
   },

--- a/docs/statistics.ipynb
+++ b/docs/statistics.ipynb
@@ -8,20 +8,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "%run ./phase-space.ipynb"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,7 +29,6 @@
    },
    "outputs": [],
    "source": [
-    "# pyright: reportUndefinedVariable=false\n",
     "from __future__ import annotations\n",
     "\n",
     "import jax.numpy as jnp\n",
@@ -54,7 +39,18 @@
     "from tqdm.notebook import tqdm\n",
     "\n",
     "from polarization import formulate_polarization\n",
-    "from polarization.io import perform_cached_doit"
+    "from polarization.amplitude import DalitzPlotDecompositionBuilder\n",
+    "from polarization.data import create_data_transformer, generate_meshgrid_sample\n",
+    "from polarization.io import mute_jax_warnings, perform_cached_doit\n",
+    "from polarization.lhcb import load_model_parameters, load_three_body_decays\n",
+    "\n",
+    "mute_jax_warnings()\n",
+    "\n",
+    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "decay = dynamics_configurator.decay\n",
+    "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
+    "amplitude_builder.dynamics_choices = dynamics_configurator\n",
+    "model = amplitude_builder.formulate()"
    ]
   },
   {
@@ -221,7 +217,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X, Y, data, phsp_filter = generate_uniform_phsp(resolution=200)"
+    "transformer = create_data_transformer(model)\n",
+    "phsp = generate_meshgrid_sample(decay, resolution=200)\n",
+    "data = transformer(phsp)\n",
+    "X = data[\"sigma1\"]\n",
+    "Y = data[\"sigma2\"]"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ known_third_party = "THIRDPARTY,sympy"
 
 [tool.nbqa.addopts]
 flake8 = [
-    "--extend-ignore=E501,E731,F821",
+    "--extend-ignore=E501,E731",
 ]
 
 [tool.pytest.ini_options]

--- a/src/polarization/amplitude/__init__.py
+++ b/src/polarization/amplitude/__init__.py
@@ -28,6 +28,7 @@ else:
 
 @frozen
 class AmplitudeModel:
+    decay: ThreeBodyDecay
     intensity: sp.Expr = sp.S.One
     amplitudes: dict[sp.Indexed, sp.Expr] = field(factory=dict)
     variables: dict[sp.Symbol, sp.Expr] = field(factory=dict)
@@ -71,6 +72,7 @@ class DalitzPlotDecompositionBuilder:
         }
         parameter_defaults.update(masses)
         return AmplitudeModel(
+            decay=self.decay,
             intensity=PoolSum(
                 sp.Abs(aligned_amp) ** 2,
                 *allowed_helicities.items(),
@@ -129,6 +131,7 @@ class DalitzPlotDecompositionBuilder:
         amp_symbol = A[subsystem_id][λ0, λ1, λ2, λ3]
         amp_expr = sp.Add(*terms)
         return AmplitudeModel(
+            decay=self.decay,
             intensity=sp.Abs(amp_symbol) ** 2,
             amplitudes={amp_symbol: amp_expr},
             variables={θij: θij_expr},

--- a/src/polarization/data.py
+++ b/src/polarization/data.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import sympy as sp
+from ampform.kinematics.phasespace import compute_third_mandelstam, is_within_phasespace
+from tensorwaves.data import (
+    IntensityDistributionGenerator,
+    NumpyDomainGenerator,
+    NumpyUniformRNG,
+    SympyDataTransformer,
+)
+from tensorwaves.function import PositionalArgumentFunction
+from tensorwaves.function.sympy import create_function
+from tensorwaves.interface import DataSample
+
+from polarization.amplitude import AmplitudeModel
+from polarization.decay import ThreeBodyDecay
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
+
+def create_data_transformer(model: AmplitudeModel) -> SympyDataTransformer:
+    kinematic_variables = {
+        symbol: expression.doit().subs(model.parameter_defaults)
+        for symbol, expression in model.variables.items()
+    }
+    identity_mapping = {s: s for s in sp.symbols("sigma1:4", nonnegative=True)}
+    kinematic_variables.update(identity_mapping)
+    return SympyDataTransformer.from_sympy(
+        kinematic_variables, backend="jax", use_cse=False
+    )
+
+
+def create_phase_space_filter(
+    decay: ThreeBodyDecay,
+    x_mandelstam: Literal[1, 2, 3] = 1,
+    y_mandelstam: Literal[1, 2, 3] = 2,
+    outside_value=sp.nan,
+) -> PositionalArgumentFunction:
+    m0, m1, m2, m3 = create_mass_symbol_mapping(decay).values()
+    sigma_x = sp.Symbol(f"sigma{x_mandelstam}", nonnegative=True)
+    sigma_y = sp.Symbol(f"sigma{y_mandelstam}", nonnegative=True)
+    in_phsp_expr = is_within_phasespace(sigma_x, sigma_y, m0, m1, m2, m3, outside_value)
+    return create_function(in_phsp_expr.doit(), backend="jax", use_cse=True)
+
+
+def generate_meshgrid_sample(
+    decay: ThreeBodyDecay,
+    resolution: int,
+    x_mandelstam: Literal[1, 2, 3] = 1,
+    y_mandelstam: Literal[1, 2, 3] = 2,
+) -> DataSample:
+    """Generate a `numpy.meshgrid` sample for plotting with `matplotlib.pyplot`."""
+    boundaries = __compute_dalitz_boundaries(decay)
+    sigma_x, sigma_y = np.meshgrid(
+        np.linspace(*boundaries[x_mandelstam - 1], num=resolution),
+        np.linspace(*boundaries[y_mandelstam - 1], num=resolution),
+    )
+    phsp = {
+        f"sigma{x_mandelstam}": sigma_x,
+        f"sigma{y_mandelstam}": sigma_y,
+    }
+    z_mandelstam = __get_third_mandelstam_index(x_mandelstam, y_mandelstam)
+    compute_sigma_z = __create_compute_compute_sigma_z(
+        decay, x_mandelstam, y_mandelstam
+    )
+    phsp[f"sigma{z_mandelstam}"] = compute_sigma_z(phsp)
+    return phsp
+
+
+def generate_phasespace_sample(decay: ThreeBodyDecay, n_events: int, seed=None):
+    boundaries = __compute_dalitz_boundaries(decay)
+    domain_generator = NumpyDomainGenerator(
+        boundaries={
+            "sigma1": boundaries[0],
+            "sigma2": boundaries[1],
+        }
+    )
+    phsp_filter = create_phase_space_filter(decay, outside_value=0)
+    phsp_generator = IntensityDistributionGenerator(domain_generator, phsp_filter)
+    rng = NumpyUniformRNG(seed)
+    phsp = phsp_generator.generate(n_events, rng)
+    compute_sigma_z = __create_compute_compute_sigma_z(decay)
+    phsp["sigma3"] = compute_sigma_z(phsp)
+    return phsp
+
+
+def __compute_dalitz_boundaries(
+    decay: ThreeBodyDecay,
+) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    m0, m1, m2, m3 = create_mass_symbol_mapping(decay).values()
+    return (
+        ((m2 + m3) ** 2, (m0 - m1) ** 2),
+        ((m3 + m1) ** 2, (m0 - m2) ** 2),
+        ((m1 + m2) ** 2, (m0 - m3) ** 2),
+    )
+
+
+def __create_compute_compute_sigma_z(
+    decay: ThreeBodyDecay,
+    x_mandelstam: Literal[1, 2, 3] = 1,
+    y_mandelstam: Literal[1, 2, 3] = 2,
+) -> PositionalArgumentFunction:
+    m0, m1, m2, m3 = create_mass_symbol_mapping(decay).values()
+    sigma_x = sp.Symbol(f"sigma{x_mandelstam}", nonnegative=True)
+    sigma_y = sp.Symbol(f"sigma{y_mandelstam}", nonnegative=True)
+    sigma_k = compute_third_mandelstam(sigma_x, sigma_y, m0, m1, m2, m3)
+    return create_function(sigma_k, backend="jax", use_cse=True)
+
+
+def create_mass_symbol_mapping(decay: ThreeBodyDecay) -> dict[sp.Symbol, float]:
+    return {
+        sp.Symbol(f"m{i}"): decay.states[i].mass
+        for i in sorted(decay.states)  # ensure that dict keys are sorted by state ID
+    }
+
+
+def __get_third_mandelstam_index(
+    x_mandelstam: Literal[1, 2, 3], y_mandelstam: Literal[1, 2, 3]
+):
+    if x_mandelstam == y_mandelstam:
+        raise ValueError(f"x_mandelstam and y_mandelstam must be different")
+    return next(iter({1, 2, 3} - {x_mandelstam, y_mandelstam}))

--- a/src/polarization/io.py
+++ b/src/polarization/io.py
@@ -269,3 +269,8 @@ def _to_bytes(obj) -> bytes:
         # but pickle.dumps() does not always result in the same bytes stream.
         return str(obj).encode()
     return pickle.dumps(obj)
+
+
+def mute_jax_warnings() -> None:
+    jax_logger = logging.getLogger("absl")
+    jax_logger.setLevel(logging.ERROR)

--- a/src/polarization/lhcb/__init__.py
+++ b/src/polarization/lhcb/__init__.py
@@ -98,7 +98,7 @@ def load_resonance_definitions(filename: Path | str) -> dict[str, Particle]:
 def load_model_parameters(
     filename: Path | str,
     decay: ThreeBodyDecay,
-    model_id: int | str,
+    model_id: int | str = 0,
     typ: Literal["value", "uncertainty"] = "value",
 ) -> dict[sp.Indexed | sp.Symbol, complex | float]:
     with open(filename) as stream:


### PR DESCRIPTION
Extracted a `data` module from the `phase-space.ipynb` notebook functions to data module. This makes it possible to remove the 'notebook dependencies', so that each notebook is run separately (should slightly improve performance).