### PR TITLE
feat: add statistical uncertainty plots for |ɑ| and intensity

### DIFF
--- a/docs/intensity.ipynb
+++ b/docs/intensity.ipynb
@@ -56,11 +56,12 @@
     "\n",
     "mute_jax_warnings()\n",
     "\n",
+    "reference_subsystem = 1\n",
     "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
     "decay = dynamics_configurator.decay\n",
     "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
     "amplitude_builder.dynamics_choices = dynamics_configurator\n",
-    "model = amplitude_builder.formulate()\n",
+    "model = amplitude_builder.formulate(reference_subsystem)\n",
     "imported_parameter_values = load_model_parameters(\"../data/modelparameters.json\", decay)\n",
     "model.parameter_defaults.update(imported_parameter_values)"
    ]

--- a/docs/polarization.ipynb
+++ b/docs/polarization.ipynb
@@ -54,11 +54,12 @@
     "\n",
     "mute_jax_warnings()\n",
     "\n",
+    "reference_subsystem = 1\n",
     "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
     "decay = dynamics_configurator.decay\n",
     "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
     "amplitude_builder.dynamics_choices = dynamics_configurator\n",
-    "model = amplitude_builder.formulate()\n",
+    "model = amplitude_builder.formulate(reference_subsystem)\n",
     "imported_parameter_values = load_model_parameters(\"../data/modelparameters.json\", decay)\n",
     "model.parameter_defaults.update(imported_parameter_values)"
    ]
@@ -77,7 +78,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "polarization_exprs = formulate_polarization(amplitude_builder)\n",
+    "polarization_exprs = formulate_polarization(amplitude_builder, reference_subsystem)\n",
     "unfolded_polarization_exprs = [\n",
     "    perform_cached_doit(expr.doit().xreplace(model.amplitudes))\n",
     "    for expr in tqdm(polarization_exprs, desc=\"Unfolding polarization expressions\")\n",

--- a/docs/statistics.ipynb
+++ b/docs/statistics.ipynb
@@ -46,11 +46,12 @@
     "\n",
     "mute_jax_warnings()\n",
     "\n",
+    "reference_subsystem = 1\n",
     "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
     "decay = dynamics_configurator.decay\n",
     "amplitude_builder = DalitzPlotDecompositionBuilder(decay)\n",
     "amplitude_builder.dynamics_choices = dynamics_configurator\n",
-    "model = amplitude_builder.formulate()"
+    "model = amplitude_builder.formulate(reference_subsystem)"
    ]
   },
   {
@@ -69,7 +70,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "polarization_exprs = formulate_polarization(amplitude_builder)\n",
+    "polarization_exprs = formulate_polarization(amplitude_builder, reference_subsystem)\n",
     "unfolded_polarization_exprs = [\n",
     "    perform_cached_doit(expr.doit().xreplace(model.amplitudes))\n",
     "    for expr in tqdm(polarization_exprs, desc=\"Unfolding polarization expressions\")\n",

--- a/src/polarization/__init__.py
+++ b/src/polarization/__init__.py
@@ -1,11 +1,20 @@
+import sys
+
 import sympy as sp
 from ampform.sympy import PoolSum
 from sympy.physics.matrices import msigma
 
 from .amplitude import DalitzPlotDecompositionBuilder
 
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
-def formulate_polarization(builder: DalitzPlotDecompositionBuilder):
+
+def formulate_polarization(
+    builder: DalitzPlotDecompositionBuilder, reference_subsystem: Literal[1, 2, 3] = 1
+):
     spins = [builder.decay.states[i].spin for i in builder.decay.states]
     half = sp.Rational(1, 2)
     if spins != [half, half, 0, 0]:
@@ -13,13 +22,14 @@ def formulate_polarization(builder: DalitzPlotDecompositionBuilder):
             "Can only formulate polarization for an initial state with spin 1/2 and a"
             f" final state with spin 1/2, 0, 0, but got spins {spins}"
         )
-    model = builder.formulate()
+    model = builder.formulate(reference_subsystem)
     λ_p, λ_Λc, λ_Λc_prime = sp.symbols(R"lambda nu \nu^{\prime}")
+    ref = reference_subsystem
     return [
         PoolSum(
-            builder.formulate_aligned_amplitude(λ_Λc, λ_p, 0, 0)[0].conjugate()
+            builder.formulate_aligned_amplitude(λ_Λc, λ_p, 0, 0, ref)[0].conjugate()
             * pauli_matrix[_to_index(λ_Λc), _to_index(λ_Λc_prime)]
-            * builder.formulate_aligned_amplitude(λ_Λc_prime, λ_p, 0, 0)[0],
+            * builder.formulate_aligned_amplitude(λ_Λc_prime, λ_p, 0, 0, ref)[0],
             (λ_Λc, [-half, +half]),
             (λ_Λc_prime, [-half, +half]),
             (λ_p, [-half, +half]),


### PR DESCRIPTION
Follow-up to #43, now with $\left|\vec\alpha\right|$ and $I$ plots.

![image](https://user-images.githubusercontent.com/29308176/172230059-7ea068c7-a3d5-4803-b358-c4721b80b17f.png)
![image](https://user-images.githubusercontent.com/29308176/172230070-00eb2569-51f5-4639-858a-37b4c5193308.png)
