### PR TITLE
docs: embed source code in API

### DIFF
--- a/.cspell/python.txt
+++ b/.cspell/python.txt
@@ -22,6 +22,7 @@ lambdification
 lambdify
 lhcb
 linspace
+makedirs
 matplotlib
 meshgrid
 nbconvert

--- a/docs/appendix/phase-space.ipynb
+++ b/docs/appendix/phase-space.ipynb
@@ -151,7 +151,7 @@
    },
    "outputs": [],
    "source": [
-    "dynamics_configurator = load_three_body_decays(\"../data/isobars.json\")\n",
+    "dynamics_configurator = load_three_body_decays(\"../../data/isobars.json\")\n",
     "decay = dynamics_configurator.decay\n",
     "display_latex(create_mass_symbol_mapping(decay))"
    ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx_book_theme",
     "sphinx_codeautolink",
     "sphinx_copybutton",
@@ -119,3 +120,4 @@ numfig = True
 panels_add_bootstrap_css = False
 pygments_style = "sphinx"
 use_multitoc_numbering = True
+viewcode_follow_imported_members = True

--- a/src/polarization/io.py
+++ b/src/polarization/io.py
@@ -247,7 +247,8 @@ def perform_cached_doit(unevaluated_expr: sp.Expr, directory: str = ".") -> sp.E
     same as the hash embedded in the filename.
     """
     h = get_readable_hash(unevaluated_expr)
-    filename = f"{directory}/sympy-expr-{h[:7]}.pkl"
+    filename = f"{directory}/.sympy-cache/{h}.pkl"
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     if os.path.exists(filename):
         with open(filename, "rb") as f:
             return pickle.load(f)


### PR DESCRIPTION
See [`sphinx.ext.viewcode`](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html)

Other improvements:
* fix: update path to isobars definitions
* refactor: write cached expressions to sub-directory