### PR TITLE
fix: stat uncertainty of alpha from sample

### DIFF
--- a/docs/statistics.ipynb
+++ b/docs/statistics.ipynb
@@ -502,9 +502,9 @@
    "outputs": [],
    "source": [
     "ɑ_norm_weighted_mean = weighted_ɑ_norm_per_bootstrap.mean()\n",
-    "ɑ_norm_weighted_std = weighted_ɑ_norm_per_bootstrap.std() / np.sqrt(n_bootstraps)\n",
+    "ɑ_norm_weighted_std = weighted_ɑ_norm_per_bootstrap.std()\n",
     "ɑ_weighted_mean = weighted_ɑ_per_bootstrap.mean(axis=1)\n",
-    "ɑ_weighted_std = weighted_ɑ_per_bootstrap.std(axis=1) / np.sqrt(n_bootstraps)\n",
+    "ɑ_weighted_std = weighted_ɑ_per_bootstrap.std(axis=1)\n",
     "src = Rf\"\"\"\n",
     "\\begin{{array}}{{ccr}}\n",
     "  \\overline{{\\alpha_x}} & = & {ɑ_weighted_mean[0]:.4f} \\pm {ɑ_weighted_std[0]:.4f} \\\\\n",


### PR DESCRIPTION
RMS is actually the error.
 1. It is clear from a trivial example when observable is one or the generated parameters. The RMS would match the gaussian sigma
 2. The stat uncertainty should not depend on the size of the pseudoexperiments sample
 3. I had in mind that the uncertainty of the sample `mean` is `sigma / sqrt(N)`, but actually we are interested in the width of distribution rather than in its mean.