### PR TITLE
fix: use same model numbers as definition file

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -524,7 +524,7 @@
     "systematic_intensities = []\n",
     "systematic_polarizations = []\n",
     "systematic_fit_fractions = defaultdict(list)\n",
-    "for title in tqdm(model_parameters.model_titles):\n",
+    "for title in tqdm(model_parameters.model_titles.values()):\n",
     "    new_parameters = convert_dict_keys(\n",
     "        model_parameters.get_parameter_values(title),\n",
     "        key_converter=str,\n",
@@ -814,7 +814,9 @@
    "outputs": [],
    "source": [
     "src = \"|   |\"\n",
-    "for i, _ in enumerate(model_parameters.model_titles[1:], 1):\n",
+    "for i in model_parameters.model_titles:\n",
+    "    if i == 0:\n",
+    "        continue\n",
     "    src += f\" {i} |\"\n",
     "src += \"\\n\"\n",
     "for _ in model_parameters.model_titles:\n",
@@ -838,7 +840,7 @@
     "            src += f\"{diff} | \"\n",
     "    src += \"\\n\"\n",
     "\n",
-    "for i, title in enumerate(model_parameters.model_titles):\n",
+    "for i, title in model_parameters.model_titles.items():\n",
     "    src += f\"\\n- **{i}**: {title}\"\n",
     "Markdown(src)"
    ]
@@ -971,7 +973,7 @@
     "    {\n",
     "        title.strip(\".\"): (f\"{x:+.4f}\", f\"{y:+.4f}\", f\"{z:+.4f}\", f\"{norm:+.4f}\")\n",
     "        for title, (x, y, z), norm in zip(\n",
-    "            model_parameters.model_titles, alpha_sys_diff, alpha_norm_sys_diff\n",
+    "            model_parameters.model_titles.values(), alpha_sys_diff, alpha_norm_sys_diff\n",
     "        )\n",
     "    }\n",
     ").transpose().rename(columns={0: \"ɑx\", 1: \"ɑy\", 2: \"ɑz\", 3: \"|ɑ|\"})"

--- a/src/polarization/lhcb/__init__.py
+++ b/src/polarization/lhcb/__init__.py
@@ -110,18 +110,19 @@ class ModelParameters:
     ) -> None:
         with open(filename) as stream:
             json_data = json.load(stream)
-        self.__model_titles: tuple[str, ...] = tuple(
-            model["title"] for model in json_data["modelstudies"]
-        )
+        self.__model_titles: dict[int, str] = {
+            i: model["title"] for i, model in enumerate(json_data["modelstudies"])
+        }
         if allowed_model_titles is not None:
-            self.__model_titles = tuple(
-                title
-                for title in self.__model_titles
-                if title in set(allowed_model_titles)
-            )
+            allowed_model_titles = set(allowed_model_titles)
+            self.__model_titles = {
+                i: title
+                for i, title in self.__model_titles.items()
+                if title in allowed_model_titles
+            }
         self.__values: dict[str, dict[str, complex | float | int]] = {}
         self.__uncertainties: dict[str, dict[str, complex | float | int]] = {}
-        for title in self.model_titles:
+        for title in self.model_titles.values():
             self.__values[title] = _load_model_parameters(
                 filename, decay, title, typ="value"
             )
@@ -130,8 +131,8 @@ class ModelParameters:
             )
 
     @property
-    def model_titles(self) -> tuple[str, ...]:
-        return self.__model_titles
+    def model_titles(self) -> dict[int, str]:
+        return dict(self.__model_titles)
 
     def get_parameter_values(
         self, model_title: str


### PR DESCRIPTION
Fix-up to #77 that addresses https://github.com/redeboer/polarization-sensitivity/pull/77#issuecomment-1168819124. Model numbering is now correct and also uses the same numbering as in `modelparameters.json`.

![image](https://user-images.githubusercontent.com/29308176/176248211-125a46dd-3b07-4307-841a-8c4d1c74a357.png)
Compare with https://github.com/redeboer/polarization-sensitivity/pull/77#issuecomment-1165647113