### PR TITLE
fix!: correctly calculate decay rate systematics

### DIFF
--- a/docs/intensity.ipynb
+++ b/docs/intensity.ipynb
@@ -300,7 +300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fit fractions"
+    "## Decay rates"
    ]
   },
   {
@@ -366,7 +366,7 @@
    },
    "outputs": [],
    "source": [
-    "def compute_fit_fractions(func, integration_sample: DataSample):\n",
+    "def compute_decay_rates(func, integration_sample: DataSample):\n",
     "    decay_rates = np.zeros(shape=(n_resonances, n_resonances))\n",
     "    combinations = list(product(enumerate(resonances), enumerate(resonances)))\n",
     "    progress_bar = tqdm(\n",
@@ -463,7 +463,7 @@
     "    plt.show()\n",
     "\n",
     "\n",
-    "decay_rates = compute_fit_fractions(intensity_func, integration_sample)\n",
+    "decay_rates = compute_decay_rates(intensity_func, integration_sample)\n",
     "visualize_decay_rates(decay_rates)"
    ]
   },
@@ -628,7 +628,7 @@
     "    y_range=sub_region_y_range,\n",
     ")\n",
     "sub_sample = transformer(sub_sample)\n",
-    "sub_decay_rates = compute_fit_fractions(intensity_func, sub_sample)\n",
+    "sub_decay_rates = compute_decay_rates(intensity_func, sub_sample)\n",
     "visualize_decay_rates(sub_decay_rates, title=\"Rate matrix over sub-region\")"
    ]
   },

--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -864,7 +864,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fit fractions"
+    "## Decay rates"
    ]
   },
   {
@@ -881,8 +881,8 @@
    "outputs": [],
    "source": [
     "src = r\"\"\"\n",
-    "| Resonance | Fit Fraction (%) |\n",
-    "|----------:|:-----------------|\n",
+    "| Resonance | Decay rate (%) |\n",
+    "|----------:|:---------------|\n",
     "\"\"\"\n",
     "for resonance in resonances:\n",
     "    ff_statistical = 100 * stat_decay_rates[resonance.name]\n",


### PR DESCRIPTION
Found the cause for the difference reported in https://github.com/redeboer/polarization-sensitivity/pull/104#issue-1295538609, 343102f fixes it. The problem was that the systematics loop was reusing the `intensity_array` variable from the statistics loop...

### This PR (343102f)
![image](https://user-images.githubusercontent.com/29308176/178270415-34ebfd2a-53cb-4ecf-860a-99647035c959.png)

### `main` branch (6efa1a7)
![image](https://user-images.githubusercontent.com/29308176/178270595-faacbc89-522b-4ee0-9676-35ba7829e371.png)

---

Closes #108 