### PR TITLE
build: install model definitions with package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,4 +66,5 @@ where = src
 
 [options.package_data]
 polarization.lhcb =
+    model-definitions.yaml
     particle-definitions.yaml

--- a/src/polarization/lhcb/model-definitions.yaml
+++ b/src/polarization/lhcb/model-definitions.yaml
@@ -1,0 +1,1 @@
+../../../data/model-definitions.yaml


### PR DESCRIPTION
Installs the model definitions with the `polarization` package. This is need to put the benchmark scripts under a separate repository.