### PR TITLE
docs: add 1D intensity distribution comparison

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -479,6 +479,7 @@
     "fig.suptitle(R\"Polarization sensitivity $\\vec\\alpha$ (statistical)\")\n",
     "s1_label = R\"$m^2\\left(K^-\\pi^+\\right)$ [GeV$/c^2$]\"\n",
     "s2_label = R\"$m^2\\left(pK^-\\right)$ [GeV$/c^2$]\"\n",
+    "s3_label = R\"$m^2\\left(p\\pi^+\\right)$ [GeV$/c^2$]\"\n",
     "axes[0, 0].set_ylabel(s2_label)\n",
     "axes[1, 0].set_ylabel(s2_label)\n",
     "\n",
@@ -814,6 +815,72 @@
    "metadata": {},
    "source": [
     "### Distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def plot_intensity_distributions(sigma: int) -> None:\n",
+    "    original_font_size = plt.rcParams[\"font.size\"]\n",
+    "    use_mpl_latex_fonts()\n",
+    "    plt.rc(\"font\", size=10)\n",
+    "    n_subplots = n_models - 1\n",
+    "    nrows = int(np.floor(np.sqrt(n_subplots)))\n",
+    "    ncols = int(np.ceil(n_subplots / nrows))\n",
+    "    fig, axes = plt.subplots(\n",
+    "        figsize=2.0 * np.array([ncols, nrows]),\n",
+    "        dpi=200,\n",
+    "        ncols=ncols,\n",
+    "        nrows=nrows,\n",
+    "        sharex=True,\n",
+    "        sharey=True,\n",
+    "    )\n",
+    "    fig.subplots_adjust(hspace=0, wspace=0, bottom=0.1, left=0.06)\n",
+    "    x_label = {1: s1_label, 2: s2_label, 3: s3_label}[sigma]\n",
+    "    fig.text(0.5, 0.04, x_label, ha=\"center\")\n",
+    "    fig.text(0.04, 0.5, \"$I$ (normalized)\", va=\"center\", rotation=\"vertical\")\n",
+    "    for ax in axes.flatten()[n_subplots:]:\n",
+    "        fig.delaxes(ax)\n",
+    "    items = list(enumerate(zip(axes.flatten(), syst_intensities[1:]), 1))\n",
+    "    for i, (ax, intensities) in tqdm(items):\n",
+    "        ax.set_title(f\"Model {i}\", y=0.01)\n",
+    "        ax.set_yticks([])\n",
+    "        n_bins = 80\n",
+    "        ax.hist(\n",
+    "            phsp_sample[f\"sigma{sigma}\"],\n",
+    "            weights=syst_intensities[0],\n",
+    "            bins=n_bins,\n",
+    "            density=True,\n",
+    "            color=\"red\",\n",
+    "            linewidth=0.5,\n",
+    "            histtype=\"step\",\n",
+    "            label=\"Default model\",\n",
+    "        )\n",
+    "        ax.hist(\n",
+    "            phsp_sample[f\"sigma{sigma}\"],\n",
+    "            weights=intensities,\n",
+    "            alpha=0.5,\n",
+    "            bins=n_bins,\n",
+    "            density=True,\n",
+    "        )\n",
+    "    plt.show()\n",
+    "    use_mpl_latex_fonts()\n",
+    "    plt.rc(\"font\", size=original_font_size)\n",
+    "\n",
+    "\n",
+    "plot_intensity_distributions(1)\n",
+    "plot_intensity_distributions(2)\n",
+    "plot_intensity_distributions(3)"
    ]
   },
   {


### PR DESCRIPTION
Added 1D intensity distributions for each model. They can be used to quickly check where discrepancies in the systematic uncertainties on e.g. decay rates come from while implementing the remaining models.

![image](https://user-images.githubusercontent.com/29308176/180741175-7153998d-40a4-454c-bb45-d5fec1c1969e.png)
![image](https://user-images.githubusercontent.com/29308176/180741196-061b6957-50f4-42d8-b470-1a716738856b.png)
![image](https://user-images.githubusercontent.com/29308176/180741210-a8590d6b-f989-44a7-9fe9-af7675ca8bac.png)

- **1**: Alternative amplitude model with K(892) with free mass and width
- **2**: Alternative amplitude model with L(1670) with free mass and width
- **3**: Alternative amplitude model with L(1690) with free mass and width
- **4**: Alternative amplitude model with D(1232) with free mass and width
- **5**: Alternative amplitude model with L(1600), D(1600), D(1700) with free mass and width
- **6**: Alternative amplitude model with L(1800) contribution added with free mass and width
- **7**: Alternative amplitude model with L(1810) contribution added with free mass and width
- **8**: Alternative amplitude model with D(1620) contribution added with free mass and width
- **9**: Alternative amplitude model in which a Relativistic Breit-Wigner is used for the K(700) contribution
- **10**: Alternative amplitude model with K(700) with free mass and width
- **11**: Alternative amplitude model with K(1410) contribution added with mass and width from PDG2020
- **12**: Alternative amplitude model in which a Relativistic Breit-Wigner is used for the K(1430) contribution
- **13**: Alternative amplitude model with K(1430) with free width
- **14**: Alternative amplitude model with free radial parameter d for the Lc resonance, indicated as dLc