### PR TITLE
refactor: split Gamma symbols in `FlattéSWave`

### DIFF
--- a/docs/appendix/dynamics.ipynb
+++ b/docs/appendix/dynamics.ipynb
@@ -212,8 +212,8 @@
    },
    "outputs": [],
    "source": [
-    "m1_1, m2_1, m1_2, m2_2 = sp.symbols(\"m1_1 m2_1 m1_2 m2_2\")\n",
-    "display_doit(FlattéSWave(s, m, Γ0, (m1_1, m2_1), (m1_2, m2_2)))"
+    "Γ1, Γ2, m1_1, m2_1, m1_2, m2_2 = sp.symbols(\"Gamma1 Gamma2 m1_1 m2_1 m1_2 m2_2\")\n",
+    "display_doit(FlattéSWave(s, m, (Γ1, Γ2), (m1_1, m2_1), (m1_2, m2_2)))"
    ]
   }
  ],

--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -100,6 +100,7 @@
     "    \"Alternative amplitude model with L(1690) with free mass and width\",\n",
     "    \"Alternative amplitude model with D(1232) with free mass and width\",\n",
     "    \"Alternative amplitude model with L(1600), D(1600), D(1700) with free mass and width\",\n",
+    "    \"Alternative amplitude model with free L(1405) Flatt'e widths, indicated as G1 (pK channel) and G2 (Sigmapi)\",\n",
     "    \"Alternative amplitude model with L(1800) contribution added with free mass and width\",\n",
     "    \"Alternative amplitude model with L(1810) contribution added with free mass and width\",\n",
     "    \"Alternative amplitude model with D(1620) contribution added with free mass and width\",\n",
@@ -129,8 +130,6 @@
    "source": [
     "# fmt: off\n",
     "not_implemented_models = [\n",
-    "    # No implementation for parameters like R\"\\Gamma_{2L(1405)}\"\n",
-    "    \"Alternative amplitude model with free L(1405) Flatt'e widths, indicated as G1 (pK channel) and G2 (Sigmapi)\",\n",
     "    # Only minimum LS-couplings are generated\n",
     "    \"Alternative amplitude model obtained using LS couplings\",\n",
     "]\n",

--- a/src/polarization/dynamics.py
+++ b/src/polarization/dynamics.py
@@ -124,17 +124,17 @@ class BuggBreitWigner(UnevaluatedExpression):
 @implement_doit_method
 class FlattéSWave(UnevaluatedExpression):
     # https://github.com/redeboer/polarization-sensitivity/blob/34f5330/julia/notebooks/model0.jl#L151-L161
-    def __new__(cls, s, m0, Γ0, masses1, masses2):
-        return create_expression(cls, s, m0, Γ0, masses1, masses2)
+    def __new__(cls, s, m0, widths, masses1, masses2):
+        return create_expression(cls, s, m0, widths, masses1, masses2)
 
     def evaluate(self):
-        s, m0, Γ0, (ma1, mb1), (ma2, mb2) = self.args
+        s, m0, (Γ1, Γ2), (ma1, mb1), (ma2, mb2) = self.args
         p = P(s, ma1, mb1)
         p0 = P(m0**2, ma2, mb2)
         q = P(s, ma2, mb2)
         q0 = P(m0**2, ma2, mb2)
-        Γ1 = Γ0 * (p / p0) * m0 / sp.sqrt(s)
-        Γ2 = Γ0 * (q / q0) * m0 / sp.sqrt(s)
+        Γ1 *= (p / p0) * m0 / sp.sqrt(s)
+        Γ2 *= (q / q0) * m0 / sp.sqrt(s)
         Γ = Γ1 + Γ2
         return 1 / (m0**2 - s - sp.I * m0 * Γ)
 

--- a/src/polarization/lhcb/__init__.py
+++ b/src/polarization/lhcb/__init__.py
@@ -31,7 +31,7 @@ from .dynamics import (
     formulate_exponential_bugg_breit_wigner,
     formulate_flatte_1405,
 )
-from .particle import PARTICLE_TO_ID, K, Λc, p, π
+from .particle import PARTICLE_TO_ID, K, Λc, Σ, p, π
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -368,6 +368,12 @@ def parameter_key_to_symbol(key: str) -> sp.Indexed | sp.Symbol:
     if key.startswith("M"):
         R = _stringify(key[1:])
         return sp.Symbol(Rf"m_{{{R}}}")
+    if key.startswith("G1"):
+        R = _stringify(key[2:])
+        return sp.Symbol(Rf"\Gamma_{{{R} \to {p.latex} {K.latex}}}")
+    if key.startswith("G2"):
+        R = _stringify(key[2:])
+        return sp.Symbol(Rf"\Gamma_{{{R} \to {Σ.latex} {π.latex}}}")
     if key.startswith("G"):
         R = _stringify(key[1:])
         return sp.Symbol(Rf"\Gamma_{{{R}}}")

--- a/src/polarization/lhcb/dynamics.py
+++ b/src/polarization/lhcb/dynamics.py
@@ -48,18 +48,20 @@ def formulate_flatte_1405(
     s = _get_mandelstam_s(decay)
     m1, m2 = map(_to_mass_symbol, decay.decay_products)
     mass = sp.Symbol(f"m_{{{decay.resonance.name}}}")
-    width = sp.Symbol(Rf"\Gamma_{{{decay.resonance.name}}}")
+    Γ1 = sp.Symbol(Rf"\Gamma_{{{decay.resonance.name} \to {p.latex} {K.latex}}}")
+    Γ2 = sp.Symbol(Rf"\Gamma_{{{decay.resonance.name} \to {Σ.latex} {π.latex}}}")
     mπ = _to_mass_symbol(π)
     mΣ = sp.Symbol(f"m_{{{Σ.name}}}")
     parameter_defaults = {
         mass: decay.resonance.mass,
-        width: decay.resonance.width,
+        Γ1: decay.resonance.width,
+        Γ2: decay.resonance.width,
         m1: decay.decay_products[0].mass,
         m2: decay.decay_products[1].mass,
         mπ: π.mass,
         mΣ: Σ.mass,
     }
-    dynamics = FlattéSWave(s, mass, width, (m1, m2), (mπ, mΣ))
+    dynamics = FlattéSWave(s, mass, (Γ1, Γ2), (m1, m2), (mπ, mΣ))
     return dynamics, parameter_defaults
 
 


### PR DESCRIPTION
Implemented an interpretation for
```python
"Alternative amplitude model with free L(1405) Flatt'e widths, indicated as G1 (pK channel) and G2 (Sigmapi)"
```
so that 17 of the 18 models are implemented.

---

Decay rate for $\Lambda(1405)$ increases as expected, but the systematic uncertainties in the polarizations aren't affected (compare with https://github.com/redeboer/polarization-sensitivity/pull/129#issuecomment-1193795403):

$$
\begin{split}
  \begin{array}{ccr}
    \overline{\alpha_x} & = & \left(-62.6 \pm 6.2_{-14.8}^{+12.2} \right) \times 10^{-3} \\
    \overline{\alpha_y} & = & \left(+8.9 \pm 9.2_{-24.9}^{+9.1} \right) \times 10^{-3} \\
    \overline{\alpha_z} & = & \left(-278.0 \pm 21.3_{-50.9}^{+12.6} \right) \times 10^{-3} \\
    \overline{\left|\vec{{\alpha}}\right|} & = & \left(629.3 \pm 7.4_{-12.4}^{+19.2} \right) \times 10^{-3} \\
  \end{array}
\end{split}
$$

![image](https://user-images.githubusercontent.com/29308176/180744530-66f18446-42dc-4962-8177-2a9b246afb34.png)

![sigma1](https://user-images.githubusercontent.com/29308176/180745570-f21beb3b-ca71-4210-bde7-cc641c25494d.png)
![sigma2](https://user-images.githubusercontent.com/29308176/180745578-f84abf68-5534-4e07-8be7-44693848d034.png)
![sigma3](https://user-images.githubusercontent.com/29308176/180745580-f0b293a2-8e04-4591-9216-a30d98eb3f91.png)


- **0**: Default amplitude model
- **1**: Alternative amplitude model with K(892) with free mass and width
- **2**: Alternative amplitude model with L(1670) with free mass and width
- **3**: Alternative amplitude model with L(1690) with free mass and width
- **4**: Alternative amplitude model with D(1232) with free mass and width
- **5**: Alternative amplitude model with L(1600), D(1600), D(1700) with free mass and width
- **6**: → _Alternative amplitude model with free L(1405) Flatt’e widths, indicated as G1 (pK channel) and G2 (Sigmapi)_
- **7**: Alternative amplitude model with L(1800) contribution added with free mass and width
- **8**: Alternative amplitude model with L(1810) contribution added with free mass and width
- **9**: Alternative amplitude model with D(1620) contribution added with free mass and width
- **10**: Alternative amplitude model in which a Relativistic Breit-Wigner is used for the K(700) contribution
- **11**: Alternative amplitude model with K(700) with free mass and width
- **12**: Alternative amplitude model with K(1410) contribution added with mass and width from PDG2020
- **13**: Alternative amplitude model in which a Relativistic Breit-Wigner is used for the K(1430) contribution
- **14**: Alternative amplitude model with an additional overall exponential form factor exp(-alpha q^2) multiplying Bugg lineshapes. The exponential parameter is indicated as ``alpha’’
- **15**: Alternative amplitude model with K(1430) with free width
- **16**: Alternative amplitude model with free radial parameter d for the Lc resonance, indicated as dLc