### PR TITLE
phys: use 100 instead of 200 bootstraps

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_bootstraps = 200\n",
+    "n_bootstraps = 100\n",
     "nominal_functions = jax_functions[nominal_model_title]\n",
     "bootstrap = ParameterBootstrap(model_file, nominal_model.decay, nominal_model_title)\n",
     "bootstrap_parameters = bootstrap.create_distribution(n_bootstraps, seed=0)"


### PR DESCRIPTION
As mentioned in #127, we can lower the number of bootstraps to 100. The statistical uncertainties are indeed not really affected.

### 100 boostraps (12eb3cc)
$$
\begin{split}
  \begin{array}{ccr}
    \overline{\alpha_x} & = & \left(-62.6 \pm 6.4_{-14.8}^{+8.4} \right) \times 10^{-3} \\
    \overline{\alpha_y} & = & \left(+8.9 \pm 8.5_{-12.7}^{+9.1} \right) \times 10^{-3} \\
    \overline{\alpha_z} & = & \left(-278.0 \pm 21.3_{-40.4}^{+12.6} \right) \times 10^{-3} \\
    \overline{\left|\vec{{\alpha}}\right|} & = & \left(629.3 \pm 7.0_{-12.4}^{+13.2} \right) \times 10^{-3} \\
  \end{array}
\end{split}
$$

### 200 bootstraps (`main` branch at 73b6f52)
$$
\begin{split}
  \begin{array}{ccr}
    \overline{\alpha_x} & = & \left(-62.6 \pm 6.2_{-14.8}^{+8.4} \right) \times 10^{-3} \\
    \overline{\alpha_y} & = & \left(+8.9 \pm 9.2_{-12.7}^{+9.1} \right) \times 10^{-3} \\
    \overline{\alpha_z} & = & \left(-278.0 \pm 21.3_{-40.4}^{+12.6} \right) \times 10^{-3} \\
    \overline{\left|\vec{{\alpha}}\right|} & = & \left(629.3 \pm 7.4_{-12.4}^{+13.2} \right) \times 10^{-3} \\
  \end{array}
\end{split}
$$