### PR TITLE
docs: combine exported fields into one JSON file

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -31,6 +31,7 @@
    "source": [
     "from __future__ import annotations\n",
     "\n",
+    "import json\n",
     "import logging\n",
     "import os\n",
     "from collections import defaultdict\n",
@@ -1294,6 +1295,7 @@
     "Exported {grid_resolution}x{grid_resolution} JSON grids for each bootstrap (**statistics**):\n",
     "\"\"\"\n",
     "os.makedirs(\"export\", exist_ok=True)\n",
+    "STAT_FILENAMES = []\n",
     "for i in tqdm(range(n_bootstraps)):\n",
     "    new_parameters = {k: v[i] for k, v in bootstrap_parameters.items()}\n",
     "    for key, func in nominal_functions.items():\n",
@@ -1313,6 +1315,7 @@
     "            \"parameters\": {k: f\"{v}\" for k, v in new_parameters.items()},\n",
     "        },\n",
     "    )\n",
+    "    STAT_FILENAMES.append(filename)\n",
     "    src += f\"1. {{download}}`{os.path.basename(filename)}<{filename}>`\\n\""
    ]
   },
@@ -1351,6 +1354,7 @@
     "\"\"\"\n",
     "os.makedirs(\"export\", exist_ok=True)\n",
     "items = list(enumerate(jax_functions.items()))\n",
+    "SYST_FILENAMES = []\n",
     "for i, (title, funcs) in tqdm(items):\n",
     "    for func in funcs.values():\n",
     "        func.update_parameters(original_parameters[title])\n",
@@ -1368,6 +1372,7 @@
     "            \"parameters\": {k: f\"{v}\" for k, v in func.parameters.items()},\n",
     "        },\n",
     "    )\n",
+    "    SYST_FILENAMES.append(filename)\n",
     "    src += f\"- {{download}}`[download]<{filename}>` {title}\\n\"\n",
     "src += \"```\""
    ]
@@ -1385,6 +1390,69 @@
    },
    "outputs": [],
    "source": [
+    "Markdown(src)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "models_key = \"models\"\n",
+    "bootstraps_key = \"bootstraps\"\n",
+    "s1_key = \"m^2_Kpi\"\n",
+    "s2_key = \"m^2_pK\"\n",
+    "combined_json = {\n",
+    "    models_key: [],\n",
+    "    bootstraps_key: [],\n",
+    "}\n",
+    "\n",
+    "for filename in SYST_FILENAMES:\n",
+    "    with open(filename) as f:\n",
+    "        data = json.load(f)\n",
+    "    s1_values = data[s1_key]\n",
+    "    s2_values = data[s2_key]\n",
+    "    del data[s1_key]\n",
+    "    del data[s2_key]\n",
+    "    combined_json[models_key].append(data)\n",
+    "\n",
+    "for filename in STAT_FILENAMES:\n",
+    "    with open(filename) as f:\n",
+    "        data = json.load(f)\n",
+    "    del data[s1_key]\n",
+    "    del data[s2_key]\n",
+    "    combined_json[bootstraps_key].append(data)\n",
+    "\n",
+    "combined_json[s1_key] = s1_values\n",
+    "combined_json[s2_key] = s2_values\n",
+    "\n",
+    "filename = \"export/polarization-field.json\"\n",
+    "with open(filename, \"w\") as f:\n",
+    "    json.dump(combined_json, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "byt = os.path.getsize(filename)\n",
+    "src = f\"\"\"\n",
+    "All data combined can be downloaded **{{download}}`here<{filename}>`** ({1e-6*byt:,.1f} MB).\n",
+    "\"\"\"\n",
     "Markdown(src)"
    ]
   },


### PR DESCRIPTION
See https://github.com/redeboer/polarization-sensitivity/issues/127#issuecomment-1194157744. The resulting combined file contains the fields and intensities for 17 models and all 100 bootstraps and is **63MB** — still acceptable.