### PR TITLE
docs: visualize alpha polar angle uncertainty

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -1084,7 +1084,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Uncertainty on polar angle"
+    "## Uncertainty on polarization"
    ]
   },
   {


### PR DESCRIPTION
Closes #139

_From the docs:_
> For each bootstrap or alternative model $i$, we compute the angle between each aligned polarimeter vector $\vec\alpha_i$ and the one from the nominal model,  $\vec\alpha_0$:
> 
> $$
> \cos\theta_i = \frac{\vec \alpha_i \cdot \vec \alpha_0}{|\alpha_i||\alpha_0|}.
> $$
> 
> The solid angle can then be computed as:
> 
> $$
> \delta\Omega = \int_0^{2\pi}\int_0^{\theta} \mathrm{d}\phi \, \mathrm{d}\cos\theta = 2\pi\left(1-\cos\theta\right).
> $$
> 
> The statistical uncertainty is given by taking the standard deviation on the $\delta\Omega$ distribution and the systematic uncertainty is given by taking finding $\theta_\mathrm{max} = \max\theta_i$ and computing $\delta\Omega_\mathrm{max}$ from that.
> 
> ![](https://user-images.githubusercontent.com/29308176/182590077-06cf3d1a-a32a-4062-89fe-77901f46511b.png)
> ![](https://user-images.githubusercontent.com/29308176/182590072-af9ddf7c-2476-4855-a0c3-75fd9828e926.png)