### PR TITLE
chore: speed up intensity distribution histograms

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -833,6 +833,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_formats = ['svg']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "jupyter": {
      "source_hidden": true
     },
@@ -864,26 +877,33 @@
     "    for ax in axes.flatten()[n_subplots:]:\n",
     "        fig.delaxes(ax)\n",
     "    items = list(enumerate(zip(axes.flatten(), syst_intensities[1:]), 1))\n",
+    "    n_bins = 80\n",
+    "    nominal_bin_values, bin_edges = jnp.histogram(\n",
+    "        phsp_sample[f\"sigma{sigma}\"],\n",
+    "        weights=syst_intensities[0],\n",
+    "        bins=n_bins,\n",
+    "        density=True,\n",
+    "    )\n",
     "    for i, (ax, intensities) in tqdm(items):\n",
     "        ax.set_title(f\"Model {i}\", y=0.01)\n",
     "        ax.set_yticks([])\n",
-    "        n_bins = 80\n",
-    "        ax.hist(\n",
-    "            phsp_sample[f\"sigma{sigma}\"],\n",
-    "            weights=syst_intensities[0],\n",
-    "            bins=n_bins,\n",
-    "            density=True,\n",
-    "            color=\"red\",\n",
-    "            linewidth=0.5,\n",
-    "            histtype=\"step\",\n",
-    "            label=\"Default model\",\n",
-    "        )\n",
-    "        ax.hist(\n",
+    "        bin_values, _ = jnp.histogram(\n",
     "            phsp_sample[f\"sigma{sigma}\"],\n",
     "            weights=intensities,\n",
-    "            alpha=0.5,\n",
     "            bins=n_bins,\n",
     "            density=True,\n",
+    "        )\n",
+    "        ax.fill_between(\n",
+    "            bin_edges[:-1],\n",
+    "            bin_values,\n",
+    "            alpha=0.5,\n",
+    "            step=\"pre\",\n",
+    "        )\n",
+    "        ax.step(\n",
+    "            x=bin_edges[:-1],\n",
+    "            y=nominal_bin_values,\n",
+    "            linewidth=0.3,\n",
+    "            color=\"red\",\n",
     "        )\n",
     "    plt.show()\n",
     "    use_mpl_latex_fonts()\n",
@@ -893,6 +913,19 @@
     "plot_intensity_distributions(1)\n",
     "plot_intensity_distributions(2)\n",
     "plot_intensity_distributions(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_formats = ['png']"
    ]
   },
   {


### PR DESCRIPTION
[`matplotlib.pyplot.hist()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html) is much slower than [`jax.numpy.histogram()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.histogram.html). The intensity distributions are now plotted in just a few seconds versus four minutes.