### PR TITLE
FIX: exclude `matplotlib-inline==0.1.5`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ doc =
     cairosvg
     ipywidgets
     matplotlib
+    matplotlib-inline !=0.1.5  # problem with plt.ioff()
     myst-nb >=0.14  # nb_render_markdown_format for Markdown tables
     pandas
     psutil


### PR DESCRIPTION
[`matplotlib-inline==0.1.5`](https://pypi.org/project/matplotlib-inline/0.1.5) (16 Aug 2022) causes a weird bug in the `polarization.ipynb` notebook: it cannot create a figure in non-interactive mode (`plt.ioff()`).

I haven't been able to reproduce the problem with a simple script, such as:

```python
import matplotlib.pyplot as plt
plt.ioff()
plt.figure()
```
so it seems to have something to do with either running it in a notebook and/or using a specific inline backend (e.g. `%config InlineBackend.figure_formats = ['png']`).

At any rate, working with Note that [`matplotlib-inline==0.1.3`](https://pypi.org/project/matplotlib-inline/0.1.3) was yanked.[^1] as happened prior to Aug 16th removes the problem. 

[^1]: [`matplotlib-inline==0.1.4`](https://pypi.org/project/matplotlib-inline/0.1.4) was yanked.

See also https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/24003338