### PR TITLE
FIX: set `PYTHONHASHSEED` on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ pages:
   variables:
     EXECUTE_NB: "YES"
     EXECUTE_PLUTO: "YES"
+    PYTHONHASHSEED: "0"
   artifacts:
     paths:
       - public


### PR DESCRIPTION
This should remove the following warnings:
[![image](https://user-images.githubusercontent.com/29308176/188139560-2db04d8c-bbb1-446b-9cc4-4dde6742601c.png)](https://lc2pkpi-polarimetry.docs.cern.ch/intensity.html)

Compare execution time of the [GitLab Pages build for this PR](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/24317246) (**1h16**) with that of [the build for the commit before it](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/24293695) (**1h15**).
