### PR TITLE
MAINT: test exact intensity and polarimetry values

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -1368,6 +1368,47 @@
      "source_hidden": true
     },
     "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "np.testing.assert_almost_equal(\n",
+    "    np.array(stat_decay_rates[\"L(1405)\"][:3]),\n",
+    "    [0.0796555, 0.0804976, 0.0789567],\n",
+    ")\n",
+    "np.testing.assert_almost_equal(\n",
+    "    np.array(syst_decay_rates[\"L(1405)\"]),\n",
+    "    [\n",
+    "        0.07778927,\n",
+    "        0.0788526,\n",
+    "        0.07636913,\n",
+    "        0.07770757,\n",
+    "        0.07449582,\n",
+    "        0.06787325,\n",
+    "        0.10786051,\n",
+    "        0.05249633,\n",
+    "        0.07123184,\n",
+    "        0.06196443,\n",
+    "        0.07350879,\n",
+    "        0.07771139,\n",
+    "        0.05810789,\n",
+    "        0.07665854,\n",
+    "        0.07596459,\n",
+    "        0.07734982,\n",
+    "        0.07842413,\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
      "hide-input"
     ]
    },


### PR DESCRIPTION
Added `assert` statements to the `uncertainties.ipynb` notebook so that we are notified once intensity and polarimetry values change upon refactoring. This is important for the ongoing work in #184.