### PR TITLE
FIX: call `assert_non_zero_amplitudes()` with argument

### DIFF
--- a/docs/appendix/ls-model.ipynb
+++ b/docs/appendix/ls-model.ipynb
@@ -159,7 +159,7 @@
     "        assert amplitude.doit() != 0\n",
     "\n",
     "\n",
-    "assert_non_zero_amplitudes()"
+    "assert_non_zero_amplitudes(LS_MODEL)"
    ]
   },
   {


### PR DESCRIPTION
Fixes https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/24843559