### PR TITLE
MAINT: implement GitLab CI caching

### DIFF
--- a/.cspell/physics.txt
+++ b/.cspell/physics.txt
@@ -11,4 +11,5 @@ Källén
 lineshape
 lineshapes
 ls
+SymPy
 Weisskopf

--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,13 @@ version.py
 # Temporary files
 *.pyc
 *condaenv.*
+.cache/
 .coverage
 .coverage.*
 .ipynb_checkpoints/
 .mypy*/
 .pytest_cache/
+.sympy-cache*/
 __pycache__/
 htmlcov/
 prof/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 image: python:3.8
 
-pages:
+docs:
   only:
-    - main
+    - caching-without-dependency-upgrades
   before_script:
     - apt-get update
     - apt-get install -y cm-super dvipng inkscape latexmk texlive-fonts-extra texlive-latex-extra texlive-xetex xindy
@@ -17,9 +17,18 @@ pages:
     - EXECUTE_PLUTO="YES" tox -e docnb
     - mv docs/_build/html/ public/
     - tar czf public/latex.tar.gz -C docs/_build/ latex/
-  variables:
-    PYTHONHASHSEED: "0"
   artifacts:
     paths:
       - public
     when: always
+  cache:
+    paths:
+      - .cache/pip
+      - .sympy-cache-jax
+      - .sympy-cache
+
+# https://docs.gitlab.com/ee/ci/caching/#cache-python-dependencies
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  PYTHONHASHSEED: "0"
+  SYMPY_CACHE_DIR: "$CI_PROJECT_DIR"

--- a/src/polarimetry/io.py
+++ b/src/polarimetry/io.py
@@ -254,7 +254,8 @@ def perform_cached_doit(
         unevaluated_expr: A `sympy.Expr <sympy.core.expr.Expr>` on which to call
             :code:`doit()`.
         directory: The directory in which to cache the result. If `None`, the cache
-            directory will be put under the home directory.
+            directory will be put under the home directory, or to the path specified by
+            the environment variable :code:`SYMPY_CACHE_DIR`.
 
     .. tip:: For a faster cache, set `PYTHONHASHSEED
         <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_ to a
@@ -263,8 +264,8 @@ def perform_cached_doit(
     .. seealso:: :func:`perform_cached_lambdify`
     """
     if directory is None:
-        home_directory = expanduser("~")
-        directory = abspath(f"{home_directory}/.sympy-cache")
+        main_cache_dir = _get_main_cache_dir()
+        directory = abspath(f"{main_cache_dir}/.sympy-cache")
     h = get_readable_hash(unevaluated_expr)
     filename = f"{directory}/{h}.pkl"
     if os.path.exists(filename):
@@ -301,7 +302,8 @@ def perform_cached_lambdify(
         backend: The choice of backend for the created numerical function. **WARNING**:
             this function has only been tested for :code:`backend="jax"`!
         directory: The directory in which to cache the result. If `None`, the cache
-            directory will be put under the home directory.
+            directory will be put under the home directory, or to the path specified by
+            the environment variable :code:`SYMPY_CACHE_DIR`.
 
     .. tip:: For a faster cache, set `PYTHONHASHSEED
         <https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED>`_ to a
@@ -310,8 +312,8 @@ def perform_cached_lambdify(
     .. seealso:: :func:`perform_cached_doit`
     """
     if directory is None:
-        home_directory = expanduser("~")
-        directory = abspath(f"{home_directory}/.sympy-cache-{backend}")
+        main_cache_dir = _get_main_cache_dir()
+        directory = abspath(f"{main_cache_dir}/.sympy-cache-{backend}")
     h = get_readable_hash(expr)
     filename = f"{directory}/{h}.pkl"
     if os.path.exists(filename):
@@ -326,6 +328,13 @@ def perform_cached_lambdify(
     with open(filename, "wb") as f:
         cloudpickle.dump(func, f)
     return func
+
+
+def _get_main_cache_dir() -> str:
+    cache_dir = os.environ.get("SYMPY_CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = expanduser("~")  # home directory
+    return cache_dir
 
 
 def get_readable_hash(obj) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ allowlist_externals =
 passenv =
   EXECUTE_NB
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   PYTHONHASHSEED = 0
@@ -41,6 +42,7 @@ allowlist_externals =
 passenv =
   EXECUTE_NB
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   PYTHONHASHSEED = 0
@@ -69,6 +71,7 @@ allowlist_externals =
   sphinx-build
 passenv =
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   EXECUTE_NB = yes
@@ -83,6 +86,7 @@ allowlist_externals =
   sphinx-build
 passenv =
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   FORCE_EXECUTE_NB = yes
@@ -98,6 +102,7 @@ allowlist_externals =
 passenv =
   EXECUTE_NB
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   PYTHONHASHSEED = 0
@@ -112,6 +117,7 @@ allowlist_externals =
   make
 passenv =
   EXECUTE_PLUTO
+  SYMPY_CACHE_DIR
   TERM
 setenv =
   EXECUTE_NB = yes


### PR DESCRIPTION
`pip`, SymPy and JAX caches are now shared on GitLab CI. This speeds up the builds:

| Previous commit (80f6a2c) | This PR (→ 56ec114) |
| --- | --- |
| [1h59](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/25053797) | [1h37min](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/25053804) |

---

_The dependency upgrades from #202 somehow [resulted in errors](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/25050303). This PR is a second attempt, but now without the dependency changes._