### PR TITLE
DX: use Jupyter notebook caches on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ pages:
       - .cache/pip
       - .sympy-cache-jax
       - .sympy-cache
+      - docs/_build/.jupyter_cache
 
 # https://docs.gitlab.com/ee/ci/caching/#cache-python-dependencies
 variables:


### PR DESCRIPTION
This should significantly increase CI, **but** also introduces the risk that cell output is not updated when dependencies change (wither in the `src` code or actual requirements). The notebook outputs are now only recomputed when their cell content changes.