### PR TITLE
DX: introduce GitLab cache dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,30 @@
 image: python:3.8
 
+cache:
+  - paths:
+      - .cache/pip
+  - key:
+      prefix: myst-nb
+      files:
+        - .constraints/*.txt
+        - data/*
+        # https://gitlab.com/gitlab-org/gitlab/-/issues/301161
+        # - src/polarimetry/*.py
+        # - src/polarimetry/*/*.py
+    paths:
+      - docs/_build/.jupyter_cache
+      - docs/_images
+      - docs/_static/images
+      - docs/appendix/export
+      - docs/export
+  - key:
+      prefix: sympy
+      files:
+        - .constraints/*.txt
+    paths:
+      - .sympy-cache-jax
+      - .sympy-cache
+
 pages:
   only:
     - main
@@ -21,20 +46,6 @@ pages:
     paths:
       - public
     when: always
-  cache:
-    key:
-      files:
-        - .constraints/*.txt
-        - data/*
-    paths:
-      - .cache/pip
-      - .sympy-cache-jax
-      - .sympy-cache
-      - docs/_build/.jupyter_cache
-      - docs/_images
-      - docs/_static/images
-      - docs/appendix/export
-      - docs/export
 
 # https://docs.gitlab.com/ee/ci/caching/#cache-python-dependencies
 variables:


### PR DESCRIPTION
The GitLab cache is now split up in `pip` cache, MyST-NB cache, and SymPy cache. The latter two of these caches are dependent on certain file contents, like the constraint files and data files, to address problems like https://github.com/ComPWA/polarimetry/pull/212#issuecomment-1274343918.

Unfortunately, GitLab cache dependencies are limited to only two paths (see [this issue](https://gitlab.com/gitlab-org/gitlab/-/issues/301161)), so it is not (yet) possible to [let the cache depend on the contents in the `src` folder](https://github.com/ComPWA/polarimetry/blob/f734b1b90f4fe538b3c3fc9d612e3eb03e00a64a/.gitlab-ci.yml#L8-L13).

---

Some examples of the speed-up:
- [`data` has changed](https://gitlab.cern.ch/polarimetry/Lc2pKpi-preview/-/jobs/25096244#L23), but [dependencies and therefore SymPy caches have not](https://gitlab.cern.ch/polarimetry/Lc2pKpi-preview/-/jobs/25096244#L23):
  `resonance-polarimetry.ipynb`: **[5388.54 seconds](https://gitlab.cern.ch/polarimetry/Lc2pKpi/-/jobs/25093714#L2807) → [1871.65 seconds](https://gitlab.cern.ch/polarimetry/Lc2pKpi-preview/-/jobs/25096244#L2709)**