### PR TITLE
FEAT: export averaged polarimeter vectors as JSON

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -1698,7 +1698,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Averaged polarimeter values for each model (and the difference with the alternative model):"
+    "Averaged polarimeter values for each model (and the difference with the nominal model):"
    ]
   },
   {


### PR DESCRIPTION
The averaged polarimeter vectors for both statistics and systematics are now serialized to JSON and can be downloaded from the webpage:
https://lc2pkpi-polarimetry.docs.cern.ch/_static/export/averaged-polarimeter-vectors.json

<img src="https://user-images.githubusercontent.com/29308176/197004308-4305bfb2-a591-4eda-b534-90f5c24b293f.png" width=500>

This is the first step in #226 