### PR TITLE
FIX: set seed for angular phase space generator

### DIFF
--- a/docs/zz.polarization-fit.ipynb
+++ b/docs/zz.polarization-fit.ipynb
@@ -109,9 +109,10 @@
     "# Dalitz variables\n",
     "PHSP = generate_phasespace_sample(DECAY, N_EVENTS, seed=0)\n",
     "# Decay plane variables\n",
-    "PHSP[\"phi\"] = np.random.uniform(-np.pi, +np.pi, N_EVENTS)\n",
-    "PHSP[\"cos_theta\"] = np.random.uniform(-1, +1, N_EVENTS)\n",
-    "PHSP[\"chi\"] = np.random.uniform(-np.pi, +np.pi, N_EVENTS)"
+    "RNG = np.random.default_rng(seed=0)\n",
+    "PHSP[\"phi\"] = RNG.uniform(-np.pi, +np.pi, N_EVENTS)\n",
+    "PHSP[\"cos_theta\"] = RNG.uniform(-1, +1, N_EVENTS)\n",
+    "PHSP[\"chi\"] = RNG.uniform(-np.pi, +np.pi, N_EVENTS)"
    ]
   },
   {


### PR DESCRIPTION
The RNG seed for the $(\phi, \theta, \chi)$ distribution generator was not fixed. This is the reason why the values in https://github.com/ComPWA/polarimetry/discussions/231 differ from the ones reported in https://github.com/ComPWA/polarimetry/pull/229#issuecomment-1286149896.