### PR TITLE
DOC: determine effect of propagating uncertainties

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,7 @@
   "version": "0.2",
   "ignoreWords": [
     "Sigmapi",
+    "ccrcr",
     "cmin",
     "einsum",
     "hangle",

--- a/docs/zz.polarization-fit.ipynb
+++ b/docs/zz.polarization-fit.ipynb
@@ -37,6 +37,7 @@
    "source": [
     "from __future__ import annotations\n",
     "\n",
+    "import itertools\n",
     "import json\n",
     "import logging\n",
     "import os\n",
@@ -569,8 +570,10 @@
    },
    "outputs": [],
    "source": [
-    "def perform_averaged_fit(phsp: DataSample, model_id: int) -> iminuit.Minuit:\n",
-    "    averaged_alpha = SYST_AVERAGED_POLARIMETERS[model_id]\n",
+    "def perform_averaged_fit(\n",
+    "    phsp: DataSample, averaged_alpha: tuple[float, float, float]\n",
+    ") -> iminuit.Minuit:\n",
+    "    averaged_alpha = jnp.array(averaged_alpha)\n",
     "\n",
     "    def weighted_nll(Px: float, Py: float, Pz: float) -> float:\n",
     "        I_new = compute_differential_decay_rate(Px, Py, Pz, averaged_alpha, phsp)\n",
@@ -584,8 +587,10 @@
     "\n",
     "\n",
     "SYST_FIT_RESULTS_AVERAGED = [\n",
-    "    perform_averaged_fit(PHSP, i)\n",
-    "    for i in tqdm(range(17), desc=\"Performing fits\", disable=NO_TQDM)\n",
+    "    perform_averaged_fit(PHSP, averaged_alpha)\n",
+    "    for averaged_alpha in tqdm(\n",
+    "        SYST_AVERAGED_POLARIMETERS, desc=\"Performing fits\", disable=NO_TQDM\n",
+    "    )\n",
     "]"
    ]
   },
@@ -649,6 +654,168 @@
    "outputs": [],
    "source": [
     "render_all_polarizations(SYST_FIT_RESULTS_AVERAGED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Min-max instead of all valuesalphas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In {numref}`uncertainties:Average polarimetry values`, the averaged aligned polarimeter vectors with systematic model uncertainties were found to be:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "scroll-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def get_alpha_systematics() -> (\n",
+    "    tuple[\n",
+    "        tuple[float, float],\n",
+    "        tuple[float, float],\n",
+    "        tuple[float, float],\n",
+    "    ]\n",
+    "):\n",
+    "    all_values = SYST_AVERAGED_POLARIMETERS\n",
+    "    central = all_values[0]\n",
+    "    syst = np.abs(all_values - central).max(axis=0)\n",
+    "    return tuple((μ, σ) for μ, σ in zip(central.tolist(), syst.tolist()))\n",
+    "\n",
+    "\n",
+    "def render_min_max_averaged_polarimeter() -> Latex:\n",
+    "    alpha_with_syst = get_alpha_systematics()\n",
+    "    src = R\"\"\"\n",
+    "    \\begin{array}{c|r|c}\n",
+    "      \\text{observable} & \\text{central} & \\text{stat} + \\text{syst} \\\\\n",
+    "      \\hline\n",
+    "    \"\"\"\n",
+    "    src = dedent(src)\n",
+    "    for xyz, (central, systematic) in zip(\"xyz\", alpha_with_syst):\n",
+    "        src += Rf\"  \\overline{{\\alpha}}_{xyz} \\; \\left[10^3\\right]\"\n",
+    "        src += Rf\"  & {1e3*central:+.1f} & {1e3*systematic:.1f}\"\n",
+    "        src += R\" \\\\\" \"\\n\"\n",
+    "    src += R\"\\end{array}\"\n",
+    "    return Latex(src.strip())\n",
+    "\n",
+    "\n",
+    "render_min_max_averaged_polarimeter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This list of uncertainties is determined by the _extreme deviations_ of the alternative models, whereas the uncertainties on the polarizations determined in {numref}`zz.polarization-fit:Using the averaged polarimeter vector` are determined by the averaged polarimeters of _all_ alternative models. The tables below shows that there is a loss in systematic uncertainty when we propagate uncertainties by taking computing&nbsp;$\\vec{P}$ _only_ with combinations of $\\alpha_i - \\sigma_i, \\alpha_i + \\sigma_i$ for each $i \\in x, y, z$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "scroll-input",
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def perform_combinatorics_fit() -> (\n",
+    "    tuple[\n",
+    "        list[tuple[float, float, float]],\n",
+    "        list[tuple[float, float, float]],\n",
+    "    ]\n",
+    "):\n",
+    "    alpha_with_syst = get_alpha_systematics()\n",
+    "    alpha_combinations = tuple((μ - σ, μ + σ) for μ, σ in alpha_with_syst)\n",
+    "    alphas = []\n",
+    "    polarizations = []\n",
+    "    items = list(itertools.product(*alpha_combinations))\n",
+    "    for averaged_alpha in tqdm(items):\n",
+    "        fit_result = perform_averaged_fit(PHSP, averaged_alpha)\n",
+    "        alphas.append(averaged_alpha)\n",
+    "        polarizations.append(extract_polarization(fit_result))\n",
+    "    return alphas, polarizations\n",
+    "\n",
+    "\n",
+    "def render_combinatorics_fit(\n",
+    "    alphas: list[tuple[float, float, float]],\n",
+    "    polarizations: list[tuple[float, float, float]],\n",
+    ") -> Latex:\n",
+    "    src = R\"\"\"\n",
+    "    \\begin{array}{rrr|rrr|rrr}\n",
+    "      \\alpha_x & \\alpha_y & \\alpha_z & P_x & P_y & P_z\n",
+    "      & \\Delta P_x & \\Delta P_y & \\Delta P_z \\\\\n",
+    "      \\hline\n",
+    "    \"\"\"\n",
+    "    src = dedent(src)\n",
+    "    nominal_α = 1e3 * SYST_AVERAGED_POLARIMETERS[0]\n",
+    "    nominal_p = extract_polarization(SYST_FIT_RESULTS_AVERAGED[0])\n",
+    "    nominal_p = 100 * np.array(nominal_p)\n",
+    "    for xyz in nominal_α:\n",
+    "        src += Rf\"  \\color{{gray}}{{{xyz:+.1f}}} &\"\n",
+    "    for xyz in nominal_p:\n",
+    "        src += Rf\" \\color{{gray}}{{{xyz:+.2f}}} &\"\n",
+    "    src += R\" \\\\\" \"\\n\"\n",
+    "    for alpha, polarization in zip(alphas, polarizations):\n",
+    "        polarization = 100 * np.array(polarization)\n",
+    "        αx, αy, αz = 1e3 * np.array(alpha)\n",
+    "        px, py, pz = polarization\n",
+    "        dx, dy, dz = polarization - nominal_p\n",
+    "        src += Rf\"  {αx:+5.1f} & {αy:+5.1f} & {αz:+6.1f} \"\n",
+    "        src += Rf\"& {px:+5.1f} & {py:+5.2f} & {pz:+5.1f} \"\n",
+    "        src += Rf\"& {dx:+5.2f} & {dy:+5.2f} & {dz:+5.1f} \\\\\" \"\\n\"\n",
+    "    src += R\"\\end{array}\"\n",
+    "    return Latex(src)\n",
+    "\n",
+    "\n",
+    "alphas, polarizations = perform_combinatorics_fit()\n",
+    "render_combinatorics_fit(alphas, polarizations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "nominal_p = extract_polarization(SYST_FIT_RESULTS_AVERAGED[0])\n",
+    "diff_combinatorics = np.abs(np.array(polarizations) - np.array(nominal_p))\n",
+    "px, py, pz = 100 * np.array(nominal_p)\n",
+    "σx, σy, σz = 100 * diff_combinatorics.max(axis=0)\n",
+    "src = Rf\"\"\"\n",
+    "\\begin{{array}}{{ccrcr}}\n",
+    "  P_x &=& {px:+.2f} &\\pm& {σx:.2f} \\\\\n",
+    "  P_y &=& {py:+.2f} &\\pm& {σy:.2f} \\\\\n",
+    "  P_z &=& {pz:+.2f} &\\pm& {σz:.2f} \\\\\n",
+    "\\end{{array}}\n",
+    "\"\"\"\n",
+    "del nominal_p, diff_combinatorics, px, py, pz, σx, σy, σz\n",
+    "Latex(src)"
    ]
   },
   {


### PR DESCRIPTION
First step in #226 (should do norm, phi, theta as well)

Error propagation (taking combinations of `central-syst`, `central+syst`, see combinations in table below):

$$
\begin{split}\begin{array}{ccrcr}
  P_x &=& +20.32 &\pm& 3.60 \\
  P_y &=& -0.26 &\pm& 0.34 \\
  P_z &=& -66.14 &\pm& 11.51 \\
\end{array}\end{split}
$$

Extrema on $\vec{P}$ as determined by a fit on all alternative models (used so far):

$$
\begin{split}
\begin{array}{ccc}
P_x &=& +20.32_{-2.44}^{+1.04} \\
P_y &=& -0.26_{-0.08}^{+0.17} \\
P_z &=& -66.14_{-3.32}^{+7.91} \\
\end{array}
\end{split}
$$

---

$$
\begin{split}\begin{array}{rrr|rrr|rrr}
  \alpha_x & \alpha_y & \alpha_z & P_x & P_y & P_z
  & \Delta P_x & \Delta P_y & \Delta P_z \\
  \hline
  \color{gray}{-62.6} &  \color{gray}{+8.9} &  \color{gray}{-278.0} & \color{gray}{+20.32} & \color{gray}{-0.26} & \color{gray}{-66.14} & \\
  -77.4 &  -3.8 & -318.4 & +17.7 & -0.25 & -57.4 & -2.58 & +0.01 &  +8.7 \\
  -77.4 &  -3.8 & -237.5 & +23.3 & -0.55 & -74.9 & +2.97 & -0.30 &  -8.7 \\
  -77.4 & +21.6 & -318.4 & +17.6 & -0.28 & -57.4 & -2.72 & -0.02 &  +8.7 \\
  -77.4 & +21.6 & -237.5 & +23.0 & -0.60 & -74.7 & +2.71 & -0.34 &  -8.6 \\
  -47.8 &  -3.8 & -318.4 & +17.9 & -0.04 & -58.4 & -2.43 & +0.21 &  +7.8 \\
  -47.8 &  -3.8 & -237.5 & +23.9 & -0.21 & -77.7 & +3.60 & +0.05 & -11.5 \\
  -47.8 & +21.6 & -318.4 & +17.7 & -0.07 & -58.3 & -2.57 & +0.19 &  +7.8 \\
  -47.8 & +21.6 & -237.5 & +23.6 & -0.26 & -77.5 & +3.31 & +0.00 & -11.3 \\
\end{array}\end{split}
$$