### PR TITLE
DX: add Zenodo configuration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
     ".pre-commit-config.yaml",
     ".prettierignore",
     ".vscode/*",
+    ".zenodo.json",
     "LICENSE",
     "Makefile",
     "Manifest.toml",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,70 @@
+{
+  "access_right": "open",
+  "creators": [
+    {
+      "affiliation": "Ruhr University Bochum",
+      "name": "Remco de Remco",
+      "orcid": "0000-0001-5846-2206"
+    },
+    {
+      "affiliation": "Excellence Cluster ORIGINS, Munich, Germany",
+      "name": "Mikhail Mikhasenko",
+      "orcid": "0000-0002-6969-2063"
+    },
+    {
+      "affiliation": "Ruhr University Bochum",
+      "name": "Miriam Fritsch",
+      "orcid": "0000-0002-6463-8295"
+    }
+  ],
+  "description": "The polarimeter vector field for multibody decays of a spin-half baryon is introduced as a generalisation of the baryon asymmetry parameters. Using a recent amplitude analysis of the $\\Lambda^+_\\mathrm{c} \\to p K^- \\pi^+$ decay performed at the LHCb experiment, we compute the distribution of the kinematic-dependent polarimeter vector for this process in the space of Mandelstam variables to express the polarised decay rate in a model-agnostic form. The obtained representation can facilitate polarisation measurements of the $\\Lambda^+_\\mathrm{c}$ baryon and eases inclusion of the $\\Lambda^+_\\mathrm{c} \\to p K^- \\pi^+$ decay mode in hadronic amplitude analyses.",
+  "keywords": [
+    "amplitude analysis",
+    "computer algebra system",
+    "LHCb",
+    "partial wave analysis",
+    "particle physics",
+    "polarimetry",
+    "polarization"
+  ],
+  "language": "eng",
+  "license": "GPL-3.0-or-later",
+  "references": [
+    "Fritsch et al. (2022). \"Common Partial Wave Analysis: a collaboration-independent organisation for amplitude analysis software\". https://doi.org/10.5281/zenodo.6908149.",
+    "Mikhasenko (2022). \"ThreeBodyDecay.jl: Julia implementation of the Dalitz-plot decomposition\". https://doi.org/10.5281/zenodo.7256812."
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.48550/arXiv.2208.03262",
+      "relation": "references",
+      "resource_type": "article",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.1103/PhysRevD.101.034033",
+      "relation": "references",
+      "resource_type": "article",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.6908149",
+      "relation": "references",
+      "resource_type": "software",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.7256812",
+      "relation": "references",
+      "resource_type": "software",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.594254",
+      "relation": "references",
+      "resource_type": "software",
+      "scheme": "doi"
+    }
+  ],
+  "title": "$Lambda^+_mathrm{c}$ polarimetry using the dominant hadronic mode",
+  "upload_type": "software"
+}


### PR DESCRIPTION
Added a `.zenodo.json`, which inserts metadata directly into the Zenodo release (see more info [here](https://developers.zenodo.org/#harvesting-with-multiple-filters)).