### PR TITLE
FIX: change resource_type to publication-article

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -37,7 +37,7 @@
     {
       "identifier": "10.48550/arXiv.2208.03262",
       "relation": "references",
-      "resource_type": "article",
+      "resource_type": "publication-article",
       "scheme": "doi"
     },
     {


### PR DESCRIPTION
Fixes https://github.com/ComPWA/polarimetry/pull/271#issuecomment-1385604614

Found this `resource_type` type in the example on
https://developers.zenodo.org/#add-metadata-to-your-github-repository-release