### PR TITLE
FIX: set correct resoure_type on second reference

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -43,7 +43,7 @@
     {
       "identifier": "10.1103/PhysRevD.101.034033",
       "relation": "references",
-      "resource_type": "article",
+      "resource_type": "publication-article",
       "scheme": "doi"
     },
     {


### PR DESCRIPTION
Follow-up to #274... Addresses the second Zenodo error (compare https://github.com/ComPWA/polarimetry/pull/271#issuecomment-1385604614):

```json
{
    "errors": "{'metadata': {'related_identifiers': {1: {'resource_type': [u'Not a valid type.']}}}}"
}
```