### PR TITLE
DOC: change Binder interface to Jupyter lab

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -300,6 +300,7 @@ html_theme_options = {
     ),
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
+        "notebook_interface": "jupyterlab",
     },
     "path_to_docs": "docs",
     "repository_url": "https://github.com/ComPWA/polarimetry",


### PR DESCRIPTION
_Follow-up to #280_

The `sphinx-book-theme` directives and hidden cells look better on Jupyter Lab than on Jupyter Notebook. It has some other advantages as well:

![image](https://user-images.githubusercontent.com/29308176/213311316-70dc5736-5ad1-4ab6-9978-96e66f973252.png)