### PR TITLE
DX: colorize `sphinx-build` output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ description =
   Build documentation with Sphinx
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:doclive]
@@ -57,6 +58,7 @@ description =
   Set up a server to directly preview changes to the HTML pages
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:docnb]
@@ -69,6 +71,7 @@ description =
 passenv = *
 setenv =
   EXECUTE_NB = yes
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:docnb-force]
@@ -80,6 +83,7 @@ description =
   Execute Jupyter notebooks and build documentation with Sphinx
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   FORCE_EXECUTE_NB = yes
   PYTHONHASHSEED = 0
 
@@ -88,13 +92,14 @@ allowlist_externals =
   sphinx-build
 commands =
   sphinx-build \
-    --color \
     -T \
     -b linkcheck \
     docs/ docs/_build/linkcheck
 description =
   Check external links in the documentation (requires internet connection)
 passenv = *
+setenv =
+  FORCE_COLOR = yes
 
 [testenv:pdf]
 allowlist_externals =
@@ -106,6 +111,7 @@ description =
   Create documentation as a single PDF file
 passenv = *
 setenv =
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:pdfnb]
@@ -119,6 +125,7 @@ description =
 passenv = *
 setenv =
   EXECUTE_NB = yes
+  FORCE_COLOR = yes
   PYTHONHASHSEED = 0
 
 [testenv:jcache]


### PR DESCRIPTION
- Closes https://github.com/ComPWA/repo-maintenance/issues/108
- Sets `passenv = *` to make the config DRY