### PR TITLE
FIX: update to JAX v0.4.7

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -64,8 +64,8 @@ ipython-genutils==0.2.0
 ipywidgets==8.0.5
 isoduration==20.11.0
 isort==5.12.0
-jax==0.4.6
-jaxlib==0.4.6
+jax==0.4.7
+jaxlib==0.4.7
 jedi==0.18.2
 jinja2==3.1.2
 json5==0.9.11
@@ -99,6 +99,7 @@ matplotlib-inline==0.1.6
 mdit-py-plugins==0.3.5
 mdurl==0.1.2
 mistune==2.0.5
+ml-dtypes==0.0.4
 mpmath==1.3.0
 mypy-extensions==1.0.0
 myst-nb==0.17.1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -63,8 +63,8 @@ ipython-genutils==0.2.0
 ipywidgets==8.0.5
 isoduration==20.11.0
 isort==5.12.0
-jax==0.4.6
-jaxlib==0.4.6
+jax==0.4.7
+jaxlib==0.4.7
 jedi==0.18.2
 jinja2==3.1.2
 json5==0.9.11
@@ -98,6 +98,7 @@ matplotlib-inline==0.1.6
 mdit-py-plugins==0.3.5
 mdurl==0.1.2
 mistune==2.0.5
+ml-dtypes==0.0.4
 mpmath==1.3.0
 mypy-extensions==1.0.0
 myst-nb==0.17.1

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -65,8 +65,8 @@ ipython-genutils==0.2.0
 ipywidgets==8.0.5
 isoduration==20.11.0
 isort==5.12.0
-jax==0.4.6
-jaxlib==0.4.6
+jax==0.4.7
+jaxlib==0.4.7
 jedi==0.18.2
 jinja2==3.1.2
 json5==0.9.11
@@ -100,6 +100,7 @@ matplotlib-inline==0.1.6
 mdit-py-plugins==0.3.5
 mdurl==0.1.2
 mistune==2.0.5
+ml-dtypes==0.0.4
 mpmath==1.3.0
 mypy-extensions==1.0.0
 myst-nb==0.17.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -65,8 +65,8 @@ ipython-genutils==0.2.0
 ipywidgets==8.0.5
 isoduration==20.11.0
 isort==5.12.0
-jax==0.4.6
-jaxlib==0.4.6
+jax==0.4.7
+jaxlib==0.4.7
 jedi==0.18.2
 jinja2==3.1.2
 json5==0.9.11
@@ -100,6 +100,7 @@ matplotlib-inline==0.1.6
 mdit-py-plugins==0.3.5
 mdurl==0.1.2
 mistune==2.0.5
+ml-dtypes==0.0.4
 mpmath==1.3.0
 mypy-extensions==1.0.0
 myst-nb==0.17.1


### PR DESCRIPTION
JAX v0.4.6, to which JAX was constrained in #295, has performance problems (see the many commits in https://github.com/ComPWA/tensorwaves/pull/480). This PR fixes that.