### PR TITLE
DOC: add JHEP badge to website

### DIFF
--- a/docs/index.ipynb
+++ b/docs/index.ipynb
@@ -14,6 +14,7 @@
     ":::{title} Welcome\n",
     ":::\n",
     "\n",
+    "[![10.1007/JHEP07(2023)228](https://zenodo.org/badge/doi/10.1007/JHEP07(2023)228.svg)](https://doi.org/10.1007/JHEP07(2023)228)\n",
     "[![10.48550/arXiv.2301.07010](https://zenodo.org/badge/doi/10.48550/arXiv.2301.07010.svg)](https://doi.org/10.48550/arXiv.2301.07010)\n",
     "[![10.5281/zenodo.7544989](https://zenodo.org/badge/doi/10.5281/zenodo.7544989.svg)](https://doi.org/10.5281/zenodo.7544989)"
    ]


### PR DESCRIPTION
The main page on [compwa.github.io/polarimetry](https://compwa.github.io/polarimetry) did not yet have a DOI badge for the [JHEP publication](https://link.springer.com/article/10.1007/JHEP07(2023)228).

![image](https://github.com/ComPWA/polarimetry/assets/29308176/229147cc-49bc-4a7c-ba62-f67c8fc77139)
