### PR TITLE
MAINT: upgrade AmpForm and Tensorwaves

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml -o .constraints/py3.10.txt --all-extras --no-annotate --python-version=3.10 --no-emit-package setuptools
 accessible-pygments==0.0.4
 alabaster==0.7.16
-ampform==0.14.11
+ampform==0.15.0
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -195,7 +195,7 @@ svgutils==0.3.4
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3
-tensorwaves==0.4.11
+tensorwaves==0.4.12
 terminado==0.18.0
 tinycss2==1.2.1
 tomli==2.0.1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml -o .constraints/py3.11.txt --all-extras --no-annotate --python-version=3.11 --no-emit-package setuptools
 accessible-pygments==0.0.4
 alabaster==0.7.16
-ampform==0.14.11
+ampform==0.15.0
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -194,7 +194,7 @@ svgutils==0.3.4
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3
-tensorwaves==0.4.11
+tensorwaves==0.4.12
 terminado==0.18.0
 tinycss2==1.2.1
 tornado==6.4

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml -o .constraints/py3.12.txt --all-extras --no-annotate --python-version=3.12 --no-emit-package setuptools
 accessible-pygments==0.0.4
 alabaster==0.7.16
-ampform==0.14.11
+ampform==0.15.0
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -194,7 +194,7 @@ svgutils==0.3.4
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3
-tensorwaves==0.4.11
+tensorwaves==0.4.12
 terminado==0.18.0
 tinycss2==1.2.1
 tornado==6.4

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml -o .constraints/py3.8.txt --all-extras --no-annotate --python-version=3.8 --no-emit-package setuptools
 accessible-pygments==0.0.4
 alabaster==0.7.13
-ampform==0.14.11
+ampform==0.15.0
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -199,7 +199,7 @@ svgutils==0.3.4
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3
-tensorwaves==0.4.11
+tensorwaves==0.4.12
 terminado==0.18.0
 tinycss2==1.2.1
 tomli==2.0.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml -o .constraints/py3.9.txt --all-extras --no-annotate --python-version=3.9 --no-emit-package setuptools
 accessible-pygments==0.0.4
 alabaster==0.7.16
-ampform==0.14.11
+ampform==0.15.0
 anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -196,7 +196,7 @@ svgutils==0.3.4
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3
-tensorwaves==0.4.11
+tensorwaves==0.4.12
 terminado==0.18.0
 tinycss2==1.2.1
 tomli==2.0.1


### PR DESCRIPTION
Updates to `tensorwaves` v0.14.12 to fix [this problem](https://github.com/ComPWA/polarimetry/actions/runs/8193603527/job/22407707601).


_This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow._