### PR TITLE
FIX: remove faulty f-string

### DIFF
--- a/docs/uncertainties.ipynb
+++ b/docs/uncertainties.ipynb
@@ -2541,7 +2541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.9.18"
   },
   "myst": {
    "all_links_external": true


### PR DESCRIPTION
Fixes the rendering problem of `uncertainties.ipynb` of the latest three commits:
- https://github.com/ComPWA/polarimetry/actions/runs/8314977504/job/22752798629
- https://github.com/ComPWA/polarimetry/actions/runs/8194617675/job/22429643492
- https://github.com/ComPWA/polarimetry/actions/runs/8193603527/job/22407707601

_A test run was performed here: https://github.com/ComPWA/polarimetry/actions/runs/8316146984_