### PR TITLE
DX: publish Docker containers for LaTeX workflows

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -57,6 +57,7 @@
     "conf.py",
     "data/**.json",
     "data/**.yaml",
+    "Dockerfile*",
     "docs/_templates/*",
     "julia/**",
     "LICENSE",

--- a/.github/Dockerfile.latex
+++ b/.github/Dockerfile.latex
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04
+LABEL org.opencontainers.image.description=" \
+    This image is used by the ci-docs.yml workflow of the ComPWA/polarimetry \
+    repository to generate an HTML build as well as a PDF for the documentation \
+    with notebook outputs (Jupyter notebook job). The LaTeX packages are required \
+    for building the PDF file and for having matplotlib plots with LaTeX. \
+    "
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/workspace
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    cm-super \
+    dvipng \
+    git \
+    inkscape \
+    latexmk \
+    make \
+    texlive-fonts-extra \
+    texlive-latex-extra \
+    texlive-xetex \
+    xindy && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/.github/Dockerfile.latex-small
+++ b/.github/Dockerfile.latex-small
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+LABEL org.opencontainers.image.description=" \
+    This image is used by the ci-docs.yml workflow of the ComPWA/polarimetry \
+    repository to generate a PDF for the documentation without notebook outputs \
+    (fast-pdf job). The LaTeX packages are required for building the PDF file and \
+    for having matplotlib plots with LaTeX. \
+    "
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/workspace
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    inkscape \
+    latexmk \
+    make \
+    texlive-fonts-extra \
+    texlive-xetex \
+    xindy && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/.github/workflows/latex-image.yml
+++ b/.github/workflows/latex-image.yml
@@ -1,0 +1,56 @@
+name: Publish Docker images
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        default: latest
+        description: The tag of the image to build and push
+        required: true
+
+jobs:
+  create-image:
+    name: Create Docker image
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        image-name:
+          - latex
+          - latex-small
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # https://github.com/docker/login-action/releases/tag/v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # https://github.com/docker/metadata-action/releases/tag/v5.7.0
+        with:
+          images: ghcr.io/compwa/polarimetry-${{ matrix.image-name }}
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # https://github.com/docker/build-push-action/releases/tag/v6.15.0
+        with:
+          context: .
+          file: .github/Dockerfile.${{ matrix.image-name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+      - name: Build Inventory Image
+        run: |
+          docker build -f .github/Dockerfile.${{ matrix.image-name }} . --tag ghcr.io/compwa/polarimetry-${{ matrix.image-name }}:${{ github.event.inputs.image-tag }}
+          docker push ghcr.io/compwa/polarimetry-${{ matrix.image-name }}:${{ github.event.inputs.image-tag }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/compwa/polarimetry-${{ matrix.image-name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "github.vscode-pull-request-github",
     "julialang.language-julia",
     "mhutchie.git-graph",
+    "ms-azuretools.vscode-docker",
     "ms-python.mypy-type-checker",
     "ms-python.python",
     "ms-python.vscode-pylance",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[dockerfile]": {
+    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+  },
   "[git-commit]": {
     "editor.rulers": [72],
     "rewrap.wrappingColumn": 72
@@ -37,8 +40,8 @@
     "\u03c3": true
   },
   "files.associations": {
-    "**/pixi.lock": "yaml",
-    ".cspell/*.txt": "plaintext"
+    ".cspell/*.txt": "plaintext",
+    "**/pixi.lock": "yaml"
   },
   "files.eol": "\n",
   "github-actions.workflows.pinned.workflows": [".github/workflows/ci.yml"],


### PR DESCRIPTION
Added the `Dockerfile`s that are required to create the Docker images that are available under https://github.com/orgs/ComPWA/packages?repo_name=polarimetry. The images can be updated with workflow dispatch.