### PR TITLE
FIX: put GH Pages files back in `artifact.tar`

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -187,11 +187,11 @@ jobs:
           path: docs/julia
       - name: Combine executed notebooks PDF
         run: pixi run docnb
+      - run: tar cf artifact.tar -C docs/_build/html .
       - uses: actions/upload-artifact@v4 # https://github.com/actions/upload-pages-artifact/issues/129
         with:
-          include-hidden-files: true
           name: github-pages
-          path: docs/_build/html
+          path: artifact.tar
 
   pr-preview:
     name: Push PR preview
@@ -205,6 +205,10 @@ jobs:
       - uses: actions/download-artifact@v5
         with:
           name: github-pages
+      - name: Extract artifact
+        run: |
+          tar xf artifact.tar
+          rm artifact.tar
       - name: Configure Git credentials
         run: |
           git config --global user.name "GitHub Action"


### PR DESCRIPTION
- Fixes [this problem](https://github.com/ComPWA/polarimetry/actions/runs/18343359633/job/52249922876).
- #423 introduced a bug in uploading to GitHub Pages.